### PR TITLE
Import entitlements / Authentication Methods / Proper support for PhoneBusiness Attribute

### DIFF
--- a/.github/workflows/createRelease.yaml
+++ b/.github/workflows/createRelease.yaml
@@ -1,0 +1,8 @@
+name: Workflow caller - create release
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  verify-changelog:
+    if: github.event.pull_request.merged == true
+    uses: Tools4everBV/.github/.github/workflows/createRelease.yaml@main

--- a/.github/workflows/verifyChangelog.yaml
+++ b/.github/workflows/verifyChangelog.yaml
@@ -1,0 +1,8 @@
+name: Workflow caller - verify changelog updated 
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  verify-changelog:
+    uses: Tools4everBV/.github/.github/workflows/verifyChangelog.yaml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [2.2.0] - 2026-02-13
+### Added
+- Import scripts for entitlements and authentication methods.
+- Refactored grant and revoke scripts for authentication methods to use a flat array structure and improved logging.
+- Improved audit logging and fallback display names in all permission scripts.
+- Updated README with all used API endpoints and best practices for required "None" mappings.
+- Confirmed and documented use of `$outputContext.Data` for required attributes with "None" mapping.
+
+### Changed
+- Adjusted scripts for import functionality and proper support for the PhoneBusiness attribute.
+- Refactored and standardized code formatting across all scripts for consistency.
+- Improved phone number comparison logic to ignore spaces and ensure robust matching.
+- Enhanced error handling and logging for better troubleshooting.
+
+### Fixed
+- Hotfix to support no mapped fields on delete actions.
+- Fixed issues with phone number detection and comparison in authentication scripts.
+- Fixed audit logging to always include PermissionDisplayName where possible.
+- Fixed bug: BusinessPhones should be an array, not a string, in the compare attribute logic ([#6](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-KPN-Lisa/issues/6)).
+- Fixed minor bugs and improved code hygiene (removed trailing whitespace, unnecessary blank lines, etc.).
+
+## [2.1.0] - 2025-02-03
+### Changed
+- Refactored code formatting and various fixes ([#4](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-KPN-Lisa/pull/4))
+
+### Contributors
+- @rschouten97 made their first contribution in [#4](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-KPN-Lisa/pull/4)
+
+## [2.0.0]
+### Added
+- Major improvements and new features (details not specified).
+
+

--- a/INFO_DE.md
+++ b/INFO_DE.md
@@ -1,0 +1,44 @@
+Der KPN LISA-Target-Connector verbindet KPN LISA mit der Identity & Access Management (IAM)-Lösung HelloID von Tools4ever an verschiedene Quellsysteme. Das ist vorteilhaft, da Sie so die Verwaltung von Benutzerkonten und Berechtigungen in KPN-Arbeitsplätzen automatisieren können. Daten aus Ihrem Quellsystem sind dabei immer maßgeblich, was Fehler verhindert. Sie sparen Zeit, unterstützen Ihre Organisation optimal und erhöhen die Benutzerzufriedenheit.
+
+## Was ist KPN LISA?
+
+KPN LISA ist der Name des KPN-Arbeitsplatz-Self-Service-Moduls, das auf die Verwaltung aller Formen von KPN-Arbeitsplätzen ausgerichtet ist. Das Modul unterstützt IT-Administratoren bei der Verwaltung und Absicherung von Benutzerkonten, Systemen und anderen Ressourcen in auf Microsoft Azure basierenden Firmennetzwerken. KPN LISA kann als Identity Provider (IDP) dienen und einen zentralen Zugangspunkt für im Firmennetzwerk verfügbare Ressourcen darstellen.
+
+## Warum ist eine KPN LISA-Verbindung nützlich?
+
+Mit dem HelloID KPN LISA-Connector können Organisationen ihre IT-Umgebung effizienter und effektiver verwalten. Der Connector spart so Zeit und Kosten und hebt gleichzeitig den gesamten Service auf ein höheres Niveau.
+
+Der KPN LISA-Connector ermöglicht eine Verbindung zu verschiedenen beliebten Quellsystemen. Denken Sie dabei an:
+
+* Visma Raet
+* AFAS
+
+Weitere Details zur Verbindung mit diesen Quellsystemen finden Sie weiter im Artikel.
+
+## HelloID für KPN LISA hilft Ihnen mit
+
+**Angemessene Verwaltung von Benutzerkonten:** Fügen Sie einen neuen Mitarbeiter zu Ihrem HR-System hinzu oder entfernen Sie einen Mitarbeiter? HelloID erkennt diese Änderung in Ihrem Quellsystem automatisch und leitet sie über den Connector an KPN LISA weiter. Basierend auf von HelloID festgelegten Arbeitsplatzprofilen führt KPN LISA dann Aktionen aus. So stellt KPN LISA beispielsweise dem Mitarbeiter ein Benutzerprofil und eine M365-Lizenz zur Verfügung. Wichtig zu beachten ist, dass HelloID die Aktion auf dem Konto ausführt und KPN LISA die Folgeaktionen übernimmt.
+
+**Fehlerfreie Verwaltung von Berechtigungen:** Mithilfe von Berechtigungen bestimmen Sie, zu welchen Anwendungen, Systemen und Ressourcen ein Benutzer Zugang hat. Sie möchten Berechtigungen daher fehlerfrei verwalten, um sicherzustellen, dass Benutzer den richtigen Zugang haben und gleichzeitig Ihre Umgebung so sicher wie möglich halten. Dank der Verbindung zwischen HelloID und KPN LISA müssen Sie sich darum nicht kümmern. HelloID verwaltet über Business Rules die Mitgliedschaften von Lizenzprofilen und Ressourcengruppen in KPN LISA.
+
+**Anpassen von Attributen:** Mit Gruppen bestimmen Sie auf einmal die Berechtigungen für eine Benutzergruppe. Welche Gruppenzugehörigkeiten ein Benutzer zugewiesen bekommt, hängt unter anderem von seiner Funktion und/oder Abteilung ab. Die Identifizierung dessen können Sie weitgehend automatisieren. Dieser Prozess funktioniert mithilfe von Attributen, die HelloID aus Ihrem Quellsystem abruft. Sie bestimmen selbst, auf Basis welches Attributs Sie welche Konten und Rechte in KPN LISA zuweisen möchten. Sie haben also immer die Kontrolle.
+
+## Wie HelloID mit KPN LISA integriert
+
+Mit Hilfe des KPN LISA Target Connectors verbinden Sie KPN LISA mit HelloID. Sie nutzen dabei einen HelloID Powershell Target Connector. HelloID kommuniziert über diesen Connector per Powershell mit den REST API Webservices von KPN LISA. Die Nutzung dieser API erfordert eine App-Registrierung im Microsoft Azure-Mandanten.
+
+| Änderung in KPN LISA | Verfahren in den Zielsystemen |
+| -------------------- | ----------------------------- |
+| **Neuer Mitarbeiter** | Wenn ein neuer Mitarbeiter eintritt, soll dieser Nutzer so schnell wie möglich produktiv sein. Dies erfordert unter anderem die richtigen Konten und Berechtigungen. Die Verbindung von KPN LISA und HelloID automatisiert diesen Prozess, sodass Sie sich darum nicht kümmern müssen. So erstellt HelloID basierend auf Ihrem Quellsystem automatisch die erforderlichen Konten in KPN LISA und weist Arbeitsplatzprofile und Gruppen zu. Die zugehörigen Berechtigungen werden über KPN LISA zugewiesen. |
+| **Andere Funktion Mitarbeiter** | Mitarbeiter können innerhalb einer Organisation eine neue Funktion zugewiesen bekommen. Auch kann eine bestehende Funktion neu gestaltet werden. Beide Änderungen erfordern andere Berechtigungen. Dank der Verbindung zwischen HelloID und KPN LISA erfordert dies keine manuellen Eingriffe, und HelloID passt die Arbeitsplatzprofile und Gruppen automatisch an. Die zugehörigen Berechtigungen werden über KPN LISA zugewiesen. So können Sie sicher sein, dass Benutzerkonten immer mit den aktuellen Funktionen innerhalb Ihrer Organisation übereinstimmen. |
+| **Mitarbeiter scheidet aus** | Wenn ein Mitarbeiter ausscheidet, deaktiviert HelloID automatisch das Benutzerkonto in KPN LISA. Außerdem informiert die IAM-Lösung alle beteiligten Mitarbeiter. Nach einiger Zeit entfernt HelloID das KPN LISA-Konto automatisch, wodurch der Clear-Prozess in KPN LISA gestartet wird. |
+
+## KPN LISA über HelloID mit Quellsystemen verbinden
+
+Mithilfe von HelloID können Sie verschiedene Systeme mit KPN LISA integrieren, darunter auch zahlreiche Quellsysteme. Vorteilhaft, denn so erhöhen Sie die Effizienz bei der Verwaltung von Benutzern und Berechtigungen. Sie realisieren eine sichere und konforme Umgebung, in der Benutzer stets Zugriff auf die richtigen Systeme, Ressourcen und Daten haben. Einige Beispiele für häufige Integrationen über HelloID sind:
+
+* **Visma Raet - KPN LISA Verbindung:** Mithilfe der Visma Raet - KPN LISA Verbindung erstellt die IAM-Lösung basierend auf allen relevanten Informationen aus dem beliebten HR-System automatisch die richtigen Benutzerkonten in KPN LISA und weist die erforderlichen Berechtigungen zu.
+
+* **AFAS - KPN LISA Verbindung:** Die Human Relationship Management (HRM)-Lösung von AFAS ermöglicht die Automatisierung aller HR-Prozesse im Zusammenhang mit sowohl Personal- als auch Gehaltsabrechnungen. Die AFAS - KPN LISA Verbindung stellt sicher, dass alle relevanten Informationen aus AFAS ihren Weg nach KPN LISA finden, ohne dass Sie sich darum kümmern müssen. HelloID fungiert dabei als Vermittler und stellt die korrekte Übersetzung sicher.
+
+HelloID unterstützt über 200 Connectoren und bietet dadurch ein breites Spektrum an Integrationsmöglichkeiten zwischen Ultimo und anderen Quell- und Zielsystemen. Unser Angebot an Connectoren und Integrationen erweitern wir kontinuierlich, sodass Sie mit allen beliebten Systemen integrieren können.

--- a/INFO_DE.md
+++ b/INFO_DE.md
@@ -41,47 +41,4 @@ Mithilfe von HelloID können Sie verschiedene Systeme mit KPN LISA integrieren, 
 
 * **AFAS - KPN LISA Verbindung:** Die Human Relationship Management (HRM)-Lösung von AFAS ermöglicht die Automatisierung aller HR-Prozesse im Zusammenhang mit sowohl Personal- als auch Gehaltsabrechnungen. Die AFAS - KPN LISA Verbindung stellt sicher, dass alle relevanten Informationen aus AFAS ihren Weg nach KPN LISA finden, ohne dass Sie sich darum kümmern müssen. HelloID fungiert dabei als Vermittler und stellt die korrekte Übersetzung sicher.
 
-Der KPN LISA-Target-Connector verbindet KPN LISA mit der Identity & Access Management (IAM)-Lösung HelloID von Tools4ever an verschiedene Quellsysteme. Das ist vorteilhaft, da Sie so die Verwaltung von Benutzerkonten und Berechtigungen in KPN-Arbeitsplätzen automatisieren können. Daten aus Ihrem Quellsystem sind dabei immer maßgeblich, was Fehler verhindert. Sie sparen Zeit, unterstützen Ihre Organisation optimal und erhöhen die Benutzerzufriedenheit.
-
-## Was ist KPN LISA?
-
-KPN LISA ist der Name des KPN-Arbeitsplatz-Self-Service-Moduls, das auf die Verwaltung aller Formen von KPN-Arbeitsplätzen ausgerichtet ist. Das Modul unterstützt IT-Administratoren bei der Verwaltung und Absicherung von Benutzerkonten, Systemen und anderen Ressourcen in auf Microsoft Azure basierenden Firmennetzwerken. KPN LISA kann als Identity Provider (IDP) dienen und einen zentralen Zugangspunkt für im Firmennetzwerk verfügbare Ressourcen darstellen.
-
-## Warum ist eine KPN LISA-Verbindung nützlich?
-
-Mit dem HelloID KPN LISA-Connector können Organisationen ihre IT-Umgebung effizienter und effektiver verwalten. Der Connector spart so Zeit und Kosten und hebt gleichzeitig den gesamten Service auf ein höheres Niveau.
-
-Der KPN LISA-Connector ermöglicht eine Verbindung zu verschiedenen beliebten Quellsystemen. Denken Sie dabei an:
-
-* Visma Raet
-* AFAS
-
-Weitere Details zur Verbindung mit diesen Quellsystemen finden Sie weiter im Artikel.
-
-## HelloID für KPN LISA hilft Ihnen mit
-
-**Angemessene Verwaltung von Benutzerkonten:** Fügen Sie einen neuen Mitarbeiter zu Ihrem HR-System hinzu oder entfernen Sie einen Mitarbeiter? HelloID erkennt diese Änderung in Ihrem Quellsystem automatisch und leitet sie über den Connector an KPN LISA weiter. Basierend auf von HelloID festgelegten Arbeitsplatzprofilen führt KPN LISA dann Aktionen aus. So stellt KPN LISA beispielsweise dem Mitarbeiter ein Benutzerprofil und eine M365-Lizenz zur Verfügung. Wichtig zu beachten ist, dass HelloID die Aktion auf dem Konto ausführt und KPN LISA die Folgeaktionen übernimmt.
-
-**Fehlerfreie Verwaltung von Berechtigungen:** Mithilfe von Berechtigungen bestimmen Sie, zu welchen Anwendungen, Systemen und Ressourcen ein Benutzer Zugang hat. Sie möchten Berechtigungen daher fehlerfrei verwalten, um sicherzustellen, dass Benutzer den richtigen Zugang haben und gleichzeitig Ihre Umgebung so sicher wie möglich halten. Dank der Verbindung zwischen HelloID und KPN LISA müssen Sie sich darum nicht kümmern. HelloID verwaltet über Business Rules die Mitgliedschaften von Lizenzprofilen und Ressourcengruppen in KPN LISA.
-
-**Anpassen von Attributen:** Mit Gruppen bestimmen Sie auf einmal die Berechtigungen für eine Benutzergruppe. Welche Gruppenzugehörigkeiten ein Benutzer zugewiesen bekommt, hängt unter anderem von seiner Funktion und/oder Abteilung ab. Die Identifizierung dessen können Sie weitgehend automatisieren. Dieser Prozess funktioniert mithilfe von Attributen, die HelloID aus Ihrem Quellsystem abruft. Sie bestimmen selbst, auf Basis welches Attributs Sie welche Konten und Rechte in KPN LISA zuweisen möchten. Sie haben also immer die Kontrolle.
-
-## Wie HelloID mit KPN LISA integriert
-
-Mit Hilfe des KPN LISA Target Connectors verbinden Sie KPN LISA mit HelloID. Sie nutzen dabei einen HelloID Powershell Target Connector. HelloID kommuniziert über diesen Connector per Powershell mit den REST API Webservices von KPN LISA. Die Nutzung dieser API erfordert eine App-Registrierung im Microsoft Azure-Mandanten.
-
-| Änderung in KPN LISA | Verfahren in den Zielsystemen |
-| -------------------- | ----------------------------- |
-| **Neuer Mitarbeiter** | Wenn ein neuer Mitarbeiter eintritt, soll dieser Nutzer so schnell wie möglich produktiv sein. Dies erfordert unter anderem die richtigen Konten und Berechtigungen. Die Verbindung von KPN LISA und HelloID automatisiert diesen Prozess, sodass Sie sich darum nicht kümmern müssen. So erstellt HelloID basierend auf Ihrem Quellsystem automatisch die erforderlichen Konten in KPN LISA und weist Arbeitsplatzprofile und Gruppen zu. Die zugehörigen Berechtigungen werden über KPN LISA zugewiesen. |
-| **Andere Funktion Mitarbeiter** | Mitarbeiter können innerhalb einer Organisation eine neue Funktion zugewiesen bekommen. Auch kann eine bestehende Funktion neu gestaltet werden. Beide Änderungen erfordern andere Berechtigungen. Dank der Verbindung zwischen HelloID und KPN LISA erfordert dies keine manuellen Eingriffe, und HelloID passt die Arbeitsplatzprofile und Gruppen automatisch an. Die zugehörigen Berechtigungen werden über KPN LISA zugewiesen. So können Sie sicher sein, dass Benutzerkonten immer mit den aktuellen Funktionen innerhalb Ihrer Organisation übereinstimmen. |
-| **Mitarbeiter scheidet aus** | Wenn ein Mitarbeiter ausscheidet, deaktiviert HelloID automatisch das Benutzerkonto in KPN LISA. Außerdem informiert die IAM-Lösung alle beteiligten Mitarbeiter. Nach einiger Zeit entfernt HelloID das KPN LISA-Konto automatisch, wodurch der Clear-Prozess in KPN LISA gestartet wird. |
-
-## KPN LISA über HelloID mit Quellsystemen verbinden
-
-Mithilfe von HelloID können Sie verschiedene Systeme mit KPN LISA integrieren, darunter auch zahlreiche Quellsysteme. Vorteilhaft, denn so erhöhen Sie die Effizienz bei der Verwaltung von Benutzern und Berechtigungen. Sie realisieren eine sichere und konforme Umgebung, in der Benutzer stets Zugriff auf die richtigen Systeme, Ressourcen und Daten haben. Einige Beispiele für häufige Integrationen über HelloID sind:
-
-* **Visma Raet - KPN LISA Verbindung:** Mithilfe der Visma Raet - KPN LISA Verbindung erstellt die IAM-Lösung basierend auf allen relevanten Informationen aus dem beliebten HR-System automatisch die richtigen Benutzerkonten in KPN LISA und weist die erforderlichen Berechtigungen zu.
-
-* **AFAS - KPN LISA Verbindung:** Die Human Relationship Management (HRM)-Lösung von AFAS ermöglicht die Automatisierung aller HR-Prozesse im Zusammenhang mit sowohl Personal- als auch Gehaltsabrechnungen. Die AFAS - KPN LISA Verbindung stellt sicher, dass alle relevanten Informationen aus AFAS ihren Weg nach KPN LISA finden, ohne dass Sie sich darum kümmern müssen. HelloID fungiert dabei als Vermittler und stellt die korrekte Übersetzung sicher.
-
 HelloID unterstützt über 200 Connectoren und bietet dadurch ein breites Spektrum an Integrationsmöglichkeiten zwischen Ultimo und anderen Quell- und Zielsystemen. Unser Angebot an Connectoren und Integrationen erweitern wir kontinuierlich, sodass Sie mit allen beliebten Systemen integrieren können.

--- a/Permissions/Groups/grantPermission.ps1
+++ b/Permissions/Groups/grantPermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
@@ -145,7 +145,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/Groups/grantPermission.ps1
+++ b/Permissions/Groups/grantPermission.ps1
@@ -119,9 +119,9 @@ try {
         ErrorAction     = "Stop"
     }
     
-    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -136,12 +136,12 @@ try {
     Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
-    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
     #endregion Create headers
 
     #region Add account to group
     # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: POST /api/users/{identifier}/groups
-    $actionMessage = "granting group [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+    $actionMessage = "granting group [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
 
     $grantPermissionSplatParams = @{
         Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/groups"
@@ -163,12 +163,12 @@ try {
 
         $outputContext.AuditLogs.Add([PSCustomObject]@{
                 # Action  = "" # Optional
-                Message = "Granted group [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                Message = "Granted group [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                 IsError = $false
             })
     }
     else {
-        Write-Warning "DryRun: Would grant group [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+        Write-Warning "DryRun: Would grant group [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
     }
     #endregion Add account to group
 }

--- a/Permissions/Groups/grantPermission.ps1
+++ b/Permissions/Groups/grantPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Groups/importPermission.ps1
+++ b/Permissions/Groups/importPermission.ps1
@@ -1,0 +1,275 @@
+#################################################
+# HelloID-Conn-Prov-Target-KPN-Lisa-Groups-Import
+# Correlate to permission
+# PowerShell V2
+#################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Resolve-KPNLisaError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+
+            $errorObjectConverted = $ErrorObject.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop
+
+            if ($null -ne $errorObjectConverted.Error) {
+                if ($null -ne $errorObjectConverted.Error.Message) {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error.Message
+
+                    if ($null -ne $errorObjectConverted.Error.Code) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Error code: $($errorObjectConverted.Error.Code)"
+                    }
+
+                    if ($null -ne $errorObjectConverted.ErrorDetails) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Additional details: $($errorObjectConverted.ErrorDetails | ConvertTo-Json)"
+                    }
+                }
+                else {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error
+                }
+            }
+            else {
+                $httpErrorObj.FriendlyMessage = $ErrorObject
+            }
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+        }
+        Write-Output $httpErrorObj
+    }
+}
+
+function Convert-StringToBoolean($obj) {
+    foreach ($property in $obj.PSObject.Properties) {
+        $value = $property.Value
+        if ($value -is [string]) {
+            try {
+                $obj.$($property.Name) = [System.Convert]::ToBoolean($value)
+            }
+            catch {
+                # Handle cases where conversion fails
+                $obj.$($property.Name) = $value
+            }
+        }
+    }
+    return $obj
+}
+#endregion functions
+
+try {
+    Write-Information 'Starting target permission import for [KPN Lisa Groups]'
+
+    #region Create access token
+    $actionMessage = "creating access token"
+    
+    $createAccessTokenBody = @{
+        grant_type    = "client_credentials"
+        client_id     = $actionContext.Configuration.EntraIDAppId
+        client_secret = $actionContext.Configuration.EntraIDAppSecret
+        scope         = $actionContext.Configuration.KPNMWPScope
+    }
+    
+    $createAccessTokenSplatParams = @{
+        Uri             = "https://login.microsoftonline.com/$($actionContext.Configuration.EntraIDTenantID)/oauth2/v2.0/token/"
+        Headers         = $headers
+        Method          = "POST"
+        ContentType     = "application/x-www-form-urlencoded"
+        UseBasicParsing = $true
+        Body            = $createAccessTokenBody
+        Verbose         = $false
+        ErrorAction     = "Stop"
+    }
+    
+    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    #endregion Create access token
+    
+    #region Create headers
+    $actionMessage = "creating headers"
+    
+    $headers = @{
+        "Accept"          = "application/json"
+        "Content-Type"    = "application/json;charset=utf-8"
+        "Mwp-Api-Version" = "1.0"
+    }
+    
+    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+
+    # Add Authorization after printing splat
+    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    #endregion Create headers
+
+    #region Get Groups
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/groups
+    $actionMessage = "querying groups"
+
+    $kpnLisaGroups = [System.Collections.ArrayList]@()
+    do {
+        $getKPNLisaGroupsSplatParams = @{
+            Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/groups"
+            Method      = "GET"
+            Body        = @{
+                Top       = 999
+                SkipToken = $Null
+            }
+            Verbose     = $false
+            ErrorAction = "Stop"
+        }
+        if (-not[string]::IsNullOrEmpty($getKPNLisaGroupsResponse.'nextLink')) {
+            $getKPNLisaGroupsSplatParams.Body.SkipToken = $getKPNLisaGroupsResponse.'nextLink'
+        }
+
+        Write-Verbose "SplatParams: $($getKPNLisaGroupsSplatParams | ConvertTo-Json)"
+
+        # Add header after printing splat
+        $getKPNLisaGroupsSplatParams['Headers'] = $headers
+
+        $getKPNLisaGroupsResponse = $null
+        $getKPNLisaGroupsResponse = Invoke-RestMethod @getKPNLisaGroupsSplatParams
+
+        if ($getKPNLisaGroupsResponse.Value -is [array]) {
+            [void]$kpnLisaGroups.AddRange($getKPNLisaGroupsResponse.Value)
+        }
+        else {
+            [void]$kpnLisaGroups.Add($getKPNLisaGroupsResponse.Value)
+        }
+    } while (-not[string]::IsNullOrEmpty($getKPNLisaGroupsResponse.'nextLink'))
+
+    # Filter out onPremisesSyncEnabled groups as they can only be managed onPremises
+    $kpnLisaGroups = $kpnLisaGroups | Where-Object { $_.onPremisesSyncEnabled -ne $true }
+    
+    # Filter out grouptypes that cannot be managed from Lisa
+    $unSupportedGroupTypes = @("SoftwareUpdatePolicy", "MWP_DeviceDeploymentProfile", "MWP_UserWorkspaceProfile")
+    $kpnLisaGroups = $kpnLisaGroups | Where-Object { $_.groupType -notin $unSupportedGroupTypes }
+
+    Write-Information "Queried groups. Result count: $(($kpnLisaGroups | Measure-Object).Count)"
+    #endregion Get Groups
+
+    #region Get Groupmembers
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/groups/{identifier}/members
+    $actionMessage = "querying Kpn Lisa Group Members"
+    foreach ($kpnLisaGroup in $kpnLisaGroups) {
+        $kpnLisaGroupMembers = [System.Collections.ArrayList]@()
+
+        do {
+            $getKPNLisaGroupMembersSplatParams = @{
+                Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/groups/$($kpnLisaGroup.id)/members"
+                Method      = "GET"
+                Body        = @{
+                    Top       = 999
+                    SkipToken = $Null
+                }
+                Verbose     = $false
+                ErrorAction = "Stop"
+            }
+            if (-not[string]::IsNullOrEmpty($getKPNLisaGroupMembersResponse.'nextLink')) {
+                $getKPNLisaGroupMembersSplatParams.Body.SkipToken = $getKPNLisaGroupMembersResponse.'nextLink'
+            }
+
+            Write-Verbose "SplatParams: $($getKPNLisaGroupMembersSplatParams | ConvertTo-Json)"
+
+            # Add header after printing splat
+            $getKPNLisaGroupMembersSplatParams['Headers'] = $headers
+
+            $getKPNLisaGroupMembersResponse = $null
+            $getKPNLisaGroupMembersResponse = Invoke-RestMethod @getKPNLisaGroupMembersSplatParams
+            $getKPNLisaGroupMembersResponseValue = $getKPNLisaGroupMembersResponse.Value | Where-Object { $_.'memberType' -eq "User" }
+
+            if ($getKPNLisaGroupMembersResponseValue -is [array]) {
+                [void]$kpnLisaGroupMembers.AddRange($getKPNLisaGroupMembersResponseValue)
+            }
+            else {
+                [void]$kpnLisaGroupMembers.Add($getKPNLisaGroupMembersResponseValue)
+            }
+        } while (-not[string]::IsNullOrEmpty($getKPNLisaGroupMembersResponse.'nextLink'))
+        $numberOfAccounts = $(($kpnLisaGroupMembers | Measure-Object).Count)
+
+        # Make sure the displayname has a value of max 100 char
+        if (-not([string]::IsNullOrEmpty($kpnLisaGroup.displayName))) {
+            $displayname = $($kpnLisaGroup.displayName).substring(0, [System.Math]::Min(100, $($kpnLisaGroup.displayName).Length))
+        }
+        else {
+            $displayname = $kpnLisaGroup.id
+        }
+        # Make sure the description has a value of max 100 char
+        if (-not([string]::IsNullOrEmpty($kpnLisaGroup.description))) {
+            $description = $($kpnLisaGroup.description).substring(0, [System.Math]::Min(100, $($kpnLisaGroup.description).Length))
+        }
+        else {
+            $description = $null
+        }
+
+        $permission = @{
+            PermissionReference = @{
+                Id = $kpnLisaGroup.id
+            }       
+            Description         = $description
+            DisplayName         = $displayName
+        }
+
+        # Batch permissions based on the amount of account references, 
+        # to make sure the output objects are not above the limit
+        $accountsBatchSize = 500
+        if ($numberOfAccounts -gt 0) {
+            $accountsBatchSize = 500
+            $batches = 0..($numberOfAccounts - 1) | Group-Object { [math]::Floor($_ / $accountsBatchSize ) }
+            foreach ($batch in $batches) {
+                $permission.AccountReferences = [array]($batch.Group | ForEach-Object { @($kpnLisaGroupMembers[$_].id) })
+                Write-Output $permission
+            }
+        }
+    }
+    Write-Information 'Target permission import for [KPN Lisa Groups] completed'
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-KPNLisaError -ErrorObject $ex
+        $auditMessage = "Error $($actionMessage). Error: $($errorObj.FriendlyMessage)"
+        $warningMessage = "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error $($actionMessage). Error: $($ex.Exception.Message)"
+        $warningMessage = "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+
+    Write-Warning $warningMessage
+
+    # Required to write an error as uniqueness check doesn't show auditlog
+    Write-Error $auditMessage
+}

--- a/Permissions/Groups/importPermission.ps1
+++ b/Permissions/Groups/importPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Groups/importPermission.ps1
+++ b/Permissions/Groups/importPermission.ps1
@@ -107,7 +107,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -119,7 +119,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -145,7 +145,7 @@ try {
             $getKPNLisaGroupsSplatParams.Body.SkipToken = $getKPNLisaGroupsResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaGroupsSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaGroupsSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaGroupsSplatParams['Headers'] = $headers
@@ -192,7 +192,7 @@ try {
                 $getKPNLisaGroupMembersSplatParams.Body.SkipToken = $getKPNLisaGroupMembersResponse.'nextLink'
             }
 
-            Write-Verbose "SplatParams: $($getKPNLisaGroupMembersSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($getKPNLisaGroupMembersSplatParams | ConvertTo-Json)"
 
             # Add header after printing splat
             $getKPNLisaGroupMembersSplatParams['Headers'] = $headers

--- a/Permissions/Groups/permissions.ps1
+++ b/Permissions/Groups/permissions.ps1
@@ -187,9 +187,7 @@ try {
             @{
                 displayName    = $displayName
                 identification = @{
-                    Id   = $_.id
-                    Name = $_.displayName
-                    Type = $_.groupType
+                    Id = $_.id
                 }
             }
         )

--- a/Permissions/Groups/permissions.ps1
+++ b/Permissions/Groups/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
             $getKPNLisaGroupsSplatParams.Body.SkipToken = $getKPNLisaGroupsResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaGroupsSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaGroupsSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaGroupsSplatParams['Headers'] = $headers

--- a/Permissions/Groups/permissions.ps1
+++ b/Permissions/Groups/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Groups/revokePermission.ps1
+++ b/Permissions/Groups/revokePermission.ps1
@@ -119,9 +119,9 @@ try {
         ErrorAction     = "Stop"
     }
     
-    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -136,12 +136,12 @@ try {
     Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
-    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
     #endregion Create headers
 
     #region Remove account from group
     # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: DELETE /api/users/{identifier}/groups/{groupidentifier}
-    $actionMessage = "revoking group [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+    $actionMessage = "revoking group [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
 
     $revokePermissionSplatParams = @{
         Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/groups/$($actionContext.References.Permission.id)"
@@ -161,12 +161,12 @@ try {
 
         $outputContext.AuditLogs.Add([PSCustomObject]@{
                 # Action  = "" # Optional
-                Message = "Revoked group [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                Message = "Revoked group [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                 IsError = $false
             })
     }
     else {
-        Write-Warning "DryRun: Would revoke group [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+        Write-Warning "DryRun: Would revoke group [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
     }
     #endregion Remove account from group
 }

--- a/Permissions/Groups/revokePermission.ps1
+++ b/Permissions/Groups/revokePermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Groups/revokePermission.ps1
+++ b/Permissions/Groups/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
@@ -143,7 +143,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/LicenseProfiles/grantPermission.ps1
+++ b/Permissions/LicenseProfiles/grantPermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -148,7 +148,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/LicenseProfiles/grantPermission.ps1
+++ b/Permissions/LicenseProfiles/grantPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/LicenseProfiles/permissions.ps1
+++ b/Permissions/LicenseProfiles/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
             $getKPNLisaLicenseProfilesSplatParams.Body.SkipToken = $getKPNLisaLicenseProfilesResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaLicenseProfilesSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaLicenseProfilesSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaLicenseProfilesSplatParams['Headers'] = $headers

--- a/Permissions/LicenseProfiles/permissions.ps1
+++ b/Permissions/LicenseProfiles/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/LicenseProfiles/revokePermission.ps1
+++ b/Permissions/LicenseProfiles/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/LicenseProfiles/revokePermission.ps1
+++ b/Permissions/LicenseProfiles/revokePermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Licenses/grantPermission.ps1
+++ b/Permissions/Licenses/grantPermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -149,7 +149,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/Licenses/grantPermission.ps1
+++ b/Permissions/Licenses/grantPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Licenses/permissions.ps1
+++ b/Permissions/Licenses/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
             $getKPNLisaLicensesSplatParams.Body.SkipToken = $getKPNLisaLicensesResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaLicensesSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaLicensesSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaLicensesSplatParams['Headers'] = $headers

--- a/Permissions/Licenses/permissions.ps1
+++ b/Permissions/Licenses/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Licenses/revokePermission.ps1
+++ b/Permissions/Licenses/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/Licenses/revokePermission.ps1
+++ b/Permissions/Licenses/revokePermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Teams/grantPermission.ps1
+++ b/Permissions/Teams/grantPermission.ps1
@@ -8,14 +8,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Teams/grantPermission.ps1
+++ b/Permissions/Teams/grantPermission.ps1
@@ -114,7 +114,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -126,7 +126,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -150,7 +150,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/Teams/permissions.ps1
+++ b/Permissions/Teams/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
             $getKPNLisaTeamsSplatParams.Body.SkipToken = $getKPNLisaTeamsResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaTeamsSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaTeamsSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaTeamsSplatParams['Headers'] = $headers

--- a/Permissions/Teams/permissions.ps1
+++ b/Permissions/Teams/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/Teams/revokePermission.ps1
+++ b/Permissions/Teams/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/Teams/revokePermission.ps1
+++ b/Permissions/Teams/revokePermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/WorkspaceProfiles/grantPermission.ps1
+++ b/Permissions/WorkspaceProfiles/grantPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/WorkspaceProfiles/grantPermission.ps1
+++ b/Permissions/WorkspaceProfiles/grantPermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -145,7 +145,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/WorkspaceProfiles/permissions.ps1
+++ b/Permissions/WorkspaceProfiles/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
             $getKPNLisaWorkspaceProfilesSplatParams.Body.SkipToken = $getKPNLisaWorkspaceProfilesResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaWorkspaceProfilesSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaWorkspaceProfilesSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaWorkspaceProfilesSplatParams['Headers'] = $headers

--- a/Permissions/WorkspaceProfiles/permissions.ps1
+++ b/Permissions/WorkspaceProfiles/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/WorkspaceProfiles/revokePermission.ps1
+++ b/Permissions/WorkspaceProfiles/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/WorkspaceProfiles/revokePermission.ps1
+++ b/Permissions/WorkspaceProfiles/revokePermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/authenticationMethods/grantPermission.ps1
+++ b/Permissions/authenticationMethods/grantPermission.ps1
@@ -1,0 +1,386 @@
+#################################################
+# HelloID-Conn-Prov-Target-KPN-Lisa-Permissions-AuthenticationMethods-Grant
+# Grant authentication method to account
+# PowerShell V2
+#################################################
+
+# Permission configuration
+$onlySetWhenEmpty = $false
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Resolve-KPNLisaError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+            $errorObjectConverted = $ErrorObject.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop
+
+            if ($null -ne $errorObjectConverted.Error) {
+                if ($null -ne $errorObjectConverted.Error.Message) {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error.Message
+
+                    if ($null -ne $errorObjectConverted.Error.Code) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Error code: $($errorObjectConverted.Error.Code)"
+                    }
+
+                    if ($null -ne $errorObjectConverted.ErrorDetails) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Additional details: $($errorObjectConverted.ErrorDetails | ConvertTo-Json)"
+                    }
+                }
+                else {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error
+                }
+            }
+            else {
+                $httpErrorObj.FriendlyMessage = $ErrorObject
+            }
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+        }
+        Write-Output $httpErrorObj
+    }
+}
+
+function Convert-StringToBoolean($obj) {
+    foreach ($property in $obj.PSObject.Properties) {
+        $value = $property.Value
+        if ($value -is [string]) {
+            try {
+                $obj.$($property.Name) = [System.Convert]::ToBoolean($value)
+            }
+            catch {
+                # Handle cases where conversion fails
+                $obj.$($property.Name) = $value
+            }
+        }
+    }
+    return $obj
+}
+#endregion functions
+try {
+
+    #region Verify account reference
+    $actionMessage = "verifying account reference"
+    if ([string]::IsNullOrEmpty($($actionContext.References.Account))) {
+        throw "The account reference could not be found"
+    }
+    #endregion Verify account reference
+    #region Create access token
+    $actionMessage = "creating access token"
+    $createAccessTokenBody = @{
+        grant_type    = "client_credentials"
+        client_id     = $actionContext.Configuration.EntraIDAppId
+        client_secret = $actionContext.Configuration.EntraIDAppSecret
+        scope         = $actionContext.Configuration.KPNMWPScope
+    }
+    $createAccessTokenSplatParams = @{
+        Uri             = "https://login.microsoftonline.com/$($actionContext.Configuration.EntraIDTenantID)/oauth2/v2.0/token/"
+        Headers         = $headers
+        Method          = "POST"
+        ContentType     = "application/x-www-form-urlencoded"
+        UseBasicParsing = $true
+        Body            = $createAccessTokenBody
+        Verbose         = $false
+        ErrorAction     = "Stop"
+    }
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    #endregion Create access token
+
+    #region Create headers
+    $actionMessage = "creating headers"
+    $headers = @{
+        "Accept"          = "application/json"
+        "Content-Type"    = "application/json;charset=utf-8"
+        "Mwp-Api-Version" = "1.0"
+    }
+    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    # Add Authorization after printing splat
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
+    #endregion Create headers
+
+    #region Get current authentication methods
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/users/{identifier}/authentication
+    $actionMessage = "querying current authentication methods for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+    $getCurrentAuthenticationMethodsSplatParams = @{
+        Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/authentication"
+        Method      = "GET"
+        Headers     = $headers
+        Verbose     = $false
+        ErrorAction = "Stop"
+    }
+    $currentAuthenticationMethods = Invoke-RestMethod @getCurrentAuthenticationMethodsSplatParams
+    Write-Verbose "Current authentication methods: $($currentAuthenticationMethods | ConvertTo-Json -Depth 10)"
+    #endregion Get current authentication methods
+    
+    #region Determine value to set
+    $valueToSet = $null
+    $currentValue = $null
+
+    # Flatten authentication methods array
+    $methods = $currentAuthenticationMethods
+    if ($methods -is [array]) {
+        $methodsArray = $methods
+    } elseif ($methods -is [hashtable] -or $methods -is [PSCustomObject]) {
+        $methodsArray = @()
+        foreach ($key in $methods.PSObject.Properties.Name) {
+            $methodsArray += $methods.$key
+        }
+    } else {
+        $methodsArray = @($methods)
+    }
+    switch ($actionContext.References.Permission.Method) {
+        "phone" {
+            # Determine which phone number to use based on type
+            switch ($actionContext.References.Permission.Type) {
+                "mobile" {
+                    $valueToSet = $PersonContext.Person.Contact.Personal.Phone.Mobile
+                    break
+                }
+                "alternateMobile" {
+                    $valueToSet = $PersonContext.Person.Contact.Personal.Phone.Mobile
+                    break
+                }
+                "office" {
+                    $valueToSet = $PersonContext.Person.Contact.Business.Phone.Mobile
+                    break
+                }
+            }
+            # Format phone number
+            if ($null -ne $valueToSet -and $valueToSet) {
+                $valueToSet = $valueToSet -replace "-", "" -replace "\s", ""
+                if ($valueToSet.StartsWith("06")) {
+                    $valueToSet = "+316" + $valueToSet.Substring(2)
+                }
+                elseif ($valueToSet.StartsWith("0031")) {
+                    $valueToSet = "+31" + $valueToSet.Substring(4)
+                }
+                elseif ($valueToSet.StartsWith("00")) {
+                    $valueToSet = "+" + $valueToSet.Substring(2)
+                }
+                if (-not $valueToSet.StartsWith("+")) {
+                    $valueToSet = "+" + $valueToSet
+                }
+            }
+            # Get current phone authentication method value from flat array
+            $currentMethod = $methodsArray | Where-Object { $_.method -eq "Phone" -and $_.phoneType -eq $actionContext.References.Permission.Type }
+            if ($null -ne $currentMethod) {
+                $currentValue = $currentMethod.phoneNumber -replace '\s', ''
+            }
+            break
+        }
+        "email" {
+            $valueToSet = $PersonContext.Person.Contact.Business.Email
+            # Get current email authentication method value from flat array
+            $currentMethod = $methodsArray | Where-Object { $_.method -eq "Email" }
+            if ($null -ne $currentMethod) {
+                $currentValue = $currentMethod.emailAddress
+            }
+            break
+        }
+    }
+    #endregion Determine value to set
+
+    #region Calculate action
+    $actionMessage = "calculating action"
+
+    if (($currentValue | Measure-Object).count -eq 0 -or [string]::IsNullOrEmpty($currentValue)) {
+        $action = 'GrantPermission'
+    }
+    elseif ($onlySetWhenEmpty -eq $true) {
+        $action = "ExistingData-SkipUpdate"
+    }
+    else {
+        # Verwijder spaties uit valueToSet voor correcte vergelijking (currentValue is al opgeschoond)
+        $valueToSetCompare = $valueToSet -replace '\s', ''
+        if ($currentValue -ne $valueToSetCompare) {
+            $action = "UpdatePermission"
+        } 
+        else {
+            $action = 'NoChanges'
+        }
+    }
+
+    Write-Information "Current value: [$currentValue], Value to set: [$valueToSet], Action: [$action]"
+    #endregion Calculate action
+
+    #region Process
+    switch ($action) {
+        'GrantPermission' {
+            $actionMessage = "creating authentication method [$($actionContext.References.Permission.Method)] - [$($actionContext.References.Permission.Type)] for account to [$valueToSet]"
+            Write-Information $actionMessage
+
+            switch ($actionContext.References.Permission.Method) {
+                "phone" {
+                    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: POST /api/users/{identifier}/authentication/phone
+                    $grantPermissionBody = @{
+                        phoneNumber = $valueToSet
+                        phoneType   = $actionContext.References.Permission.Type
+                    }
+                    break
+                }
+                "email" {
+                    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: POST /api/users/{identifier}/authentication/email
+                    $grantPermissionBody = @{
+                        emailAddress = $valueToSet
+                    }
+                    break
+                }
+            }
+
+            $grantPermissionSplatParams = @{
+                Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/authentication/$($actionContext.References.Permission.Method)"
+                Method      = "POST"
+                Body        = ($grantPermissionBody | ConvertTo-Json -Depth 10)
+                Headers     = $headers
+                Verbose     = $false
+                ErrorAction = "Stop"
+            }
+
+            $displayName = $actionContext.PermissionDisplayName
+            if ([string]::IsNullOrEmpty($displayName)) {
+                $displayName = "method: $($actionContext.References.Permission.Method), type: $($actionContext.References.Permission.Type)"
+            }
+            if (-Not($actionContext.DryRun -eq $true)) {
+                Write-Information "Granting KPN-Lisa authentication method permission: [$displayName]"
+                $grantPermissionResponse = Invoke-RestMethod @grantPermissionSplatParams
+                $outputContext.AuditLogs.Add([PSCustomObject]@{
+                        Message = "Granted authentication method permission [$displayName] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+                        IsError = $false
+                    })
+            }
+            else {
+                Write-Information "[DryRun] Grant authentication method permission: [$displayName], will be executed during enforcement"
+            }
+
+            $outputContext.Success = $true
+            break
+        }
+
+        'UpdatePermission' {
+            $actionMessage = "updating authentication method [$($actionContext.References.Permission.Method)] - [$($actionContext.References.Permission.Type)] for account to [$valueToSet]"
+            Write-Information $actionMessage
+
+            switch ($actionContext.References.Permission.Method) {
+                "phone" {
+                    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: PUT /api/users/{identifier}/authentication/phone
+                    $updatePermissionBody = @{
+                        phoneNumber = $valueToSet
+                        phoneType   = $actionContext.References.Permission.Type
+                    }
+                    break
+                }
+                "email" {
+                    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: PUT /api/users/{identifier}/authentication/email
+                    $updatePermissionBody = @{
+                        emailAddress = $valueToSet
+                    }
+                    break
+                }
+            }
+
+            $updatePermissionSplatParams = @{
+                Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/authentication/$($actionContext.References.Permission.Method)"
+                Method      = "PUT"
+                Body        = ($updatePermissionBody | ConvertTo-Json -Depth 10)
+                Headers     = $headers
+                Verbose     = $false
+                ErrorAction = "Stop"
+            }
+
+            if (-Not($actionContext.DryRun -eq $true)) {
+                Write-Information "Updating KPN-Lisa authentication method permission: [$($actionContext.PermissionDisplayName)]"
+                $updatePermissionResponse = Invoke-RestMethod @updatePermissionSplatParams
+                $outputContext.AuditLogs.Add([PSCustomObject]@{
+                        Message = "Updated authentication method permission [$($actionContext.PermissionDisplayName)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+                        IsError = $false
+                    })
+            }
+            else {
+                Write-Information "[DryRun] Update authentication method permission: [$($actionContext.PermissionDisplayName)], will be executed during enforcement"
+            }
+
+            $outputContext.Success = $true
+            break
+        }
+
+        "NoChanges" {
+            $actionMessage = "skipping setting authentication method [$($actionContext.References.Permission.Method)] - [$($actionContext.References.Permission.Type)] for account"
+            Write-Information $actionMessage
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "Skipped setting authentication method [$($actionContext.PermissionDisplayName)]. Reason: No changes"
+                    IsError = $false
+                })
+            break
+        }
+
+        "ExistingData-SkipUpdate" {
+            $actionMessage = "skipping setting authentication method [$($actionContext.References.Permission.Method)] - [$($actionContext.References.Permission.Type)] for account"
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "Skipped setting authentication method [$($actionContext.PermissionDisplayName)]. Reason: Configured to only update when empty but already contains data"
+                    IsError = $false
+                })
+            break
+        }
+    }
+    #endregion Process
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-KPNLisaError -ErrorObject $ex
+        $auditMessage = "Error $($actionMessage). Error: $($errorObj.FriendlyMessage)"
+        Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error $($actionMessage). Error: $($ex.Exception.Message)"
+        Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+
+    $outputContext.AuditLogs.Add([PSCustomObject]@{
+            Message = $auditMessage
+            IsError = $true
+        })
+}
+finally {
+    # Check if auditLogs contains errors, if no errors are found, set success to true
+    if (-NOT($outputContext.AuditLogs.IsError -contains $true)) {
+        $outputContext.Success = $true
+    }
+}

--- a/Permissions/authenticationMethods/grantPermission.ps1
+++ b/Permissions/authenticationMethods/grantPermission.ps1
@@ -109,7 +109,7 @@ try {
         ErrorAction     = "Stop"
     }
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
 
     #region Create headers
@@ -119,7 +119,7 @@ try {
         "Content-Type"    = "application/json;charset=utf-8"
         "Mwp-Api-Version" = "1.0"
     }
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
     #endregion Create headers
@@ -135,7 +135,7 @@ try {
         ErrorAction = "Stop"
     }
     $currentAuthenticationMethods = Invoke-RestMethod @getCurrentAuthenticationMethodsSplatParams
-    Write-Verbose "Current authentication methods: $($currentAuthenticationMethods | ConvertTo-Json -Depth 10)"
+    Write-Information "Current authentication methods: $($currentAuthenticationMethods | ConvertTo-Json -Depth 10)"
     #endregion Get current authentication methods
     
     #region Determine value to set
@@ -216,7 +216,6 @@ try {
         $action = "ExistingData-SkipUpdate"
     }
     else {
-        # Verwijder spaties uit valueToSet voor correcte vergelijking (currentValue is al opgeschoond)
         $valueToSetCompare = $valueToSet -replace '\s', ''
         if ($currentValue -ne $valueToSetCompare) {
             $action = "UpdatePermission"

--- a/Permissions/authenticationMethods/grantPermission.ps1
+++ b/Permissions/authenticationMethods/grantPermission.ps1
@@ -10,14 +10,6 @@ $onlySetWhenEmpty = $false
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/authenticationMethods/permissions.ps1
+++ b/Permissions/authenticationMethods/permissions.ps1
@@ -1,0 +1,54 @@
+#################################################
+# HelloID-Conn-Prov-Target-KPN-Lisa-Permissions-AuthenticationMethods-List
+# List authentication methods as permissions
+# PowerShell V2
+#################################################
+# Please see the KPN Lisa API docs: https://mwpapi.kpnwerkplek.com/index.html
+# Supported phone types: mobile, alternateMobile, office
+# Supported email type: email
+
+# Phone authentication methods
+$outputContext.Permissions.Add(
+    @{
+        DisplayName    = "Phone authentication method - mobile"
+        Identification = @{
+            Reference = "3179e48a-750b-4051-897c-87b9720928f7"
+            Type      = "mobile"
+            Method    = "phone"
+        }
+    }
+)
+
+$outputContext.Permissions.Add(
+    @{
+        DisplayName    = "Phone authentication method - alternateMobile"
+        Identification = @{
+            Reference = "b6332ec1-7057-4abe-9331-3d72feddfe41"
+            Type      = "alternateMobile"
+            Method    = "phone"
+        }
+    }
+)
+
+$outputContext.Permissions.Add(
+    @{
+        DisplayName    = "Phone authentication method - office"
+        Identification = @{
+            Reference = "e37fc753-ff3b-4958-9484-eaa9425c82bc"
+            Type      = "office"
+            Method    = "phone"
+        }
+    }
+)
+
+# Email authentication methods
+$outputContext.Permissions.Add(
+    @{
+        DisplayName    = "Email authentication method - email"
+        Identification = @{
+            Reference = "3ddfcfc8-9383-446f-83cc-3ab9be4be18f"
+            Type      = "email"
+            Method    = "email"
+        }
+    }
+)

--- a/Permissions/authenticationMethods/revokePermission.ps1
+++ b/Permissions/authenticationMethods/revokePermission.ps1
@@ -1,0 +1,295 @@
+#################################################
+# HelloID-Conn-Prov-Target-KPN-Lisa-Permissions-AuthenticationMethods-Revoke
+# Revoke authentication method from account
+# PowerShell V2
+#################################################
+
+# Permission configuration
+$removeWhenRevokingEntitlement = $false
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Resolve-KPNLisaError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+            $errorObjectConverted = $ErrorObject.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop
+
+            if ($null -ne $errorObjectConverted.Error) {
+                if ($null -ne $errorObjectConverted.Error.Message) {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error.Message
+
+                    if ($null -ne $errorObjectConverted.Error.Code) {
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Error code: $($errorObjectConverted.Error.Code)"
+                    }
+
+                    if ($null -ne $errorObjectConverted.ErrorDetails) {
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Additional details: $($errorObjectConverted.ErrorDetails | ConvertTo-Json)"
+                    }
+                }
+                else {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error
+                }
+            }
+            else {
+                $httpErrorObj.FriendlyMessage = $ErrorObject
+            }
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+        }
+        Write-Output $httpErrorObj
+    }
+}
+
+function Convert-StringToBoolean($obj) {
+    foreach ($property in $obj.PSObject.Properties) {
+        $value = $property.Value
+        if ($value -is [string]) {
+            try {
+                $obj.$($property.Name) = [System.Convert]::ToBoolean($value)
+            }
+            catch {
+                # Handle cases where conversion fails
+                $obj.$($property.Name) = $value
+            }
+        }
+    }
+    return $obj
+}
+#endregion functions
+
+try {
+    #region Verify account reference
+    $actionMessage = "verifying account reference"
+
+    if ([string]::IsNullOrEmpty($($actionContext.References.Account))) {
+        throw "The account reference could not be found"
+    }
+    #endregion Verify account reference
+
+    #region Create access token
+    $actionMessage = "creating access token"
+
+    $createAccessTokenBody = @{
+        grant_type    = "client_credentials"
+        client_id     = $actionContext.Configuration.EntraIDAppId
+        client_secret = $actionContext.Configuration.EntraIDAppSecret
+        scope         = $actionContext.Configuration.KPNMWPScope
+    }
+
+    $createAccessTokenSplatParams = @{
+        Uri             = "https://login.microsoftonline.com/$($actionContext.Configuration.EntraIDTenantID)/oauth2/v2.0/token/"
+        Headers         = $headers
+        Method          = "POST"
+        ContentType     = "application/x-www-form-urlencoded"
+        UseBasicParsing = $true
+        Body            = $createAccessTokenBody
+        Verbose         = $false
+        ErrorAction     = "Stop"
+    }
+
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
+
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    #endregion Create access token
+
+    #region Create headers
+    $actionMessage = "creating headers"
+
+    $headers = @{
+        "Accept"          = "application/json"
+        "Content-Type"    = "application/json;charset=utf-8"
+        "Mwp-Api-Version" = "1.0"
+    }
+
+    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+
+    # Add Authorization after printing splat
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
+    #endregion Create headers
+
+    #region Get current authentication methods
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/users/{identifier}/authentication
+    $actionMessage = "querying current authentication methods for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+
+    $getCurrentAuthenticationMethodsSplatParams = @{
+        Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/authentication"
+        Method      = "GET"
+        Headers     = $headers
+        Verbose     = $false
+        ErrorAction = "Stop"
+    }
+
+    $currentAuthenticationMethods = Invoke-RestMethod @getCurrentAuthenticationMethodsSplatParams
+    Write-Verbose "Current authentication methods: $($currentAuthenticationMethods | ConvertTo-Json -Depth 10)"
+    #endregion Get current authentication methods
+
+    #region Determine current value and method ID (flat array)
+    $currentValue = $null
+    $authenticationMethodId = $null
+
+    $methods = $currentAuthenticationMethods
+    if ($methods -is [array]) {
+        $methodsArray = $methods
+    } elseif ($methods -is [hashtable] -or $methods -is [PSCustomObject]) {
+        $methodsArray = @()
+        foreach ($key in $methods.PSObject.Properties.Name) {
+            $methodsArray += $methods.$key
+        }
+    } else {
+        $methodsArray = @($methods)
+    }
+
+    switch ($actionContext.References.Permission.Method) {
+        "phone" {
+            $currentMethod = $methodsArray | Where-Object { $_.method -eq "Phone" -and $_.phoneType -eq $actionContext.References.Permission.Type }
+            if ($null -ne $currentMethod) {
+                $currentValue = $currentMethod.phoneNumber
+                $authenticationMethodId = $currentMethod.id
+            }
+            break
+        }
+        "email" {
+            $currentMethod = $methodsArray | Where-Object { $_.method -eq "Email" }
+            if ($null -ne $currentMethod) {
+                $currentValue = $currentMethod.emailAddress
+                $authenticationMethodId = $currentMethod.id
+            }
+            break
+        }
+    }
+    #endregion Determine current value and method ID
+
+    #region Calculate action
+    $actionMessage = "calculating action"
+
+    if (($currentValue | Measure-Object).count -eq 0 -or [string]::IsNullOrEmpty($currentValue)) {
+        $action = 'NoExistingData-SkipDelete'
+    }
+    elseif ($removeWhenRevokingEntitlement -eq $false) {
+        $action = 'SkipDelete'
+    }
+    else {
+        $action = 'RevokePermission'
+    }
+
+    Write-Information "Current value: [$currentValue], Action: [$action]"
+    #endregion Calculate action
+
+    #region Process
+    switch ($action) {
+        'RevokePermission' {
+            # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: DELETE /api/users/{identifier}/authentication/{authenticationmethod}/{authenticationmethodId}
+            $actionMessage = "deleting authentication method [$($actionContext.References.Permission.Method)] - [$($actionContext.References.Permission.Type)] for account"
+            Write-Information $actionMessage
+
+            $revokePermissionSplatParams = @{
+                Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/authentication/$($actionContext.References.Permission.Method)/$authenticationMethodId"
+                Method      = "DELETE"
+                Headers     = $headers
+                Verbose     = $false
+                ErrorAction = "Stop"
+            }
+
+            $displayName = $actionContext.PermissionDisplayName
+            if ([string]::IsNullOrEmpty($displayName)) {
+                $displayName = "method: $($actionContext.References.Permission.Method), type: $($actionContext.References.Permission.Type)"
+            }
+            if (-not($actionContext.DryRun -eq $true)) {
+                Write-Information "Revoking KPN-Lisa authentication method permission: [$displayName]"
+                $revokePermissionResponse = Invoke-RestMethod @revokePermissionSplatParams
+
+                $outputContext.AuditLogs.Add([PSCustomObject]@{
+                        Message = "Revoked authentication method permission [$displayName] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+                        IsError = $false
+                    })
+            }
+            else {
+                Write-Information "[DryRun] Revoke authentication method permission: [$displayName], will be executed during enforcement"
+            }
+
+            $outputContext.Success = $true
+            break
+        }
+
+        'SkipDelete' {
+            $actionMessage = "skipping deleting authentication method [$($actionContext.References.Permission.Method)] - [$($actionContext.References.Permission.Type)] for account"
+            Write-Information $actionMessage
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "Skipped deleting authentication method [$($actionContext.PermissionDisplayName)]. Reason: Configured to not delete on revoke of entitlement"
+                    IsError = $false
+                })
+            break
+        }
+
+        'NoExistingData-SkipDelete' {
+            $actionMessage = "skipping deleting authentication method [$($actionContext.References.Permission.Method)] - [$($actionContext.References.Permission.Type)] for account"
+            Write-Information $actionMessage
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "Skipped deleting authentication method [$($actionContext.PermissionDisplayName)]. Reason: Nothing to delete"
+                    IsError = $false
+                })
+            break
+        }
+    }
+    #endregion Process
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-KPNLisaError -ErrorObject $ex
+        $auditMessage = "Error $($actionMessage). Error: $($errorObj.FriendlyMessage)"
+        Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error $($actionMessage). Error: $($ex.Exception.Message)"
+        Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+
+    $outputContext.AuditLogs.Add([PSCustomObject]@{
+            Message = $auditMessage
+            IsError = $true
+        })
+}
+finally {
+    # Check if auditLogs contains errors, if no errors are found, set success to true
+    if (-NOT($outputContext.AuditLogs.IsError -contains $true)) {
+        $outputContext.Success = $true
+    }
+}

--- a/Permissions/authenticationMethods/revokePermission.ps1
+++ b/Permissions/authenticationMethods/revokePermission.ps1
@@ -115,7 +115,7 @@ try {
 
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
 
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
 
     #region Create headers
@@ -127,7 +127,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
 
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
@@ -146,7 +146,7 @@ try {
     }
 
     $currentAuthenticationMethods = Invoke-RestMethod @getCurrentAuthenticationMethodsSplatParams
-    Write-Verbose "Current authentication methods: $($currentAuthenticationMethods | ConvertTo-Json -Depth 10)"
+    Write-Information "Current authentication methods: $($currentAuthenticationMethods | ConvertTo-Json -Depth 10)"
     #endregion Get current authentication methods
 
     #region Determine current value and method ID (flat array)

--- a/Permissions/authenticationMethods/revokePermission.ps1
+++ b/Permissions/authenticationMethods/revokePermission.ps1
@@ -10,14 +10,6 @@ $removeWhenRevokingEntitlement = $false
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/authorizationProfiles/grantPermission.ps1
+++ b/Permissions/authorizationProfiles/grantPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/authorizationProfiles/grantPermission.ps1
+++ b/Permissions/authorizationProfiles/grantPermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -145,7 +145,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/authorizationProfiles/permissions.ps1
+++ b/Permissions/authorizationProfiles/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -134,7 +134,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaAuthorizationProfilesSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaAuthorizationProfilesSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaAuthorizationProfilesSplatParams['Headers'] = $headers

--- a/Permissions/authorizationProfiles/permissions.ps1
+++ b/Permissions/authorizationProfiles/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/authorizationProfiles/revokePermission.ps1
+++ b/Permissions/authorizationProfiles/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -142,7 +142,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaAuthorizationProfileMembersSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaAuthorizationProfileMembersSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaAuthorizationProfileMembersSplatParams['Headers'] = $headers
@@ -151,7 +151,7 @@ try {
     $getKPNLisaAuthorizationProfileMembersResponse = Invoke-RestMethod @getKPNLisaAuthorizationProfileMembersSplatParams
     $kpnLisaAuthorizationProfileMemberObject = $getKPNLisaAuthorizationProfileMembersResponse | Where-Object { $_.objectId -eq $($actionContext.References.Account) }
 
-    Write-Verbose "Queried authorization profile member object. Result: $($kpnLisaAuthorizationProfileMemberObject | ConvertTo-Json)"
+    Write-Information "Queried authorization profile member object. Result: $($kpnLisaAuthorizationProfileMemberObject | ConvertTo-Json)"
     #endregion Get Members of AuthorizationProfile
 
     if ([string]::IsNullOrEmpty($kpnLisaAuthorizationProfileMemberObject)) {
@@ -170,7 +170,7 @@ try {
             ErrorAction = "Stop"
         }
 
-        Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
         if (-Not($actionContext.DryRun -eq $true)) {
             # Add header after printing splat

--- a/Permissions/authorizationProfiles/revokePermission.ps1
+++ b/Permissions/authorizationProfiles/revokePermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/lisaRoles/grantPermission.ps1
+++ b/Permissions/lisaRoles/grantPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/lisaRoles/grantPermission.ps1
+++ b/Permissions/lisaRoles/grantPermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -145,7 +145,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/lisaRoles/permissions.ps1
+++ b/Permissions/lisaRoles/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
             $getKPNLisaLisaRolesSplatParams.Body.SkipToken = $getKPNLisaLisaRolesResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaLisaRolesSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaLisaRolesSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaLisaRolesSplatParams['Headers'] = $headers

--- a/Permissions/lisaRoles/permissions.ps1
+++ b/Permissions/lisaRoles/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/lisaRoles/revokePermission.ps1
+++ b/Permissions/lisaRoles/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -143,7 +143,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/lisaRoles/revokePermission.ps1
+++ b/Permissions/lisaRoles/revokePermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/personas/grantPermission.ps1
+++ b/Permissions/personas/grantPermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
@@ -145,7 +145,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($grantPermissionSplatParams | ConvertTo-Json)"
 
     if (-Not($actionContext.DryRun -eq $true)) {
         # Add header after printing splat

--- a/Permissions/personas/grantPermission.ps1
+++ b/Permissions/personas/grantPermission.ps1
@@ -119,9 +119,9 @@ try {
         ErrorAction     = "Stop"
     }
     
-    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -136,12 +136,12 @@ try {
     Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
-    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
     #endregion Create headers
 
     #region Add account to persona
-    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: POST /api/Personas/{identifier}/members
-    $actionMessage = "granting persona [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: POST /api/users/{identifier}/personas
+    $actionMessage = "granting persona [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
 
     $grantPermissionSplatParams = @{
         Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/personas/$($actionContext.References.Permission.id)/members"
@@ -163,12 +163,12 @@ try {
 
         $outputContext.AuditLogs.Add([PSCustomObject]@{
                 # Action  = "" # Optional
-                Message = "Granted persona [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                Message = "Granted persona [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                 IsError = $false
             })
     }
     else {
-        Write-Warning "DryRun: Would grant persona [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+        Write-Warning "DryRun: Would grant persona [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
     }
     #endregion Add account to persona
 }
@@ -185,10 +185,17 @@ catch {
         $warningMessage = "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
     }
 
-    if ($auditMessage -like "*MemberAlreadyHasAssignment*" -and $auditMessage -like "*already is assigned to persona '$($actionContext.References.Permission.Name)' with id '$($actionContext.References.Permission.id)'*") {
+    if ($auditMessage -like "*MemberAlreadyHasAssignment*" -and $auditMessage -like "*already is assigned to persona '$($actionContext.PermissionDisplayName)' with id '$($actionContext.References.Permission.id)'*") {
         $outputContext.AuditLogs.Add([PSCustomObject]@{
                 # Action  = "" # Optional
                 Message = "Skipped $($actionMessage). Reason: User is already assigned to this persona."
+                IsError = $false
+            })
+    }
+    elseif ($auditMessage -like "*MemberAlreadyHasAssignment*" -and $auditMessage -notlike "*already is assigned to persona '$($actionContext.PermissionDisplayName)' with id '$($actionContext.References.Permission.id)'*") {
+        $outputContext.AuditLogs.Add([PSCustomObject]@{
+                # Action  = "" # Optional
+                Message = "Skipped $($actionMessage). Reason: User is already assigned to another persona."
                 IsError = $false
             })
     }

--- a/Permissions/personas/grantPermission.ps1
+++ b/Permissions/personas/grantPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/personas/importPermission.ps1
+++ b/Permissions/personas/importPermission.ps1
@@ -1,0 +1,250 @@
+#################################################
+# HelloID-Conn-Prov-Target-KPN-Lisa-Personas-Import
+# Correlate to permission
+# PowerShell V2
+#################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Resolve-KPNLisaError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+
+            $errorObjectConverted = $ErrorObject.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop
+
+            if ($null -ne $errorObjectConverted.Error) {
+                if ($null -ne $errorObjectConverted.Error.Message) {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error.Message
+
+                    if ($null -ne $errorObjectConverted.Error.Code) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Error code: $($errorObjectConverted.Error.Code)"
+                    }
+
+                    if ($null -ne $errorObjectConverted.ErrorDetails) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Additional details: $($errorObjectConverted.ErrorDetails | ConvertTo-Json)"
+                    }
+                }
+                else {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error
+                }
+            }
+            else {
+                $httpErrorObj.FriendlyMessage = $ErrorObject
+            }
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+        }
+        Write-Output $httpErrorObj
+    }
+}
+
+function Convert-StringToBoolean($obj) {
+    foreach ($property in $obj.PSObject.Properties) {
+        $value = $property.Value
+        if ($value -is [string]) {
+            try {
+                $obj.$($property.Name) = [System.Convert]::ToBoolean($value)
+            }
+            catch {
+                # Handle cases where conversion fails
+                $obj.$($property.Name) = $value
+            }
+        }
+    }
+    return $obj
+}
+#endregion functions
+
+try {
+    Write-Information 'Starting target permission import for [KPN Lisa Personas]'
+
+    #region Create access token
+    $actionMessage = "creating access token"
+    
+    $createAccessTokenBody = @{
+        grant_type    = "client_credentials"
+        client_id     = $actionContext.Configuration.EntraIDAppId
+        client_secret = $actionContext.Configuration.EntraIDAppSecret
+        scope         = $actionContext.Configuration.KPNMWPScope
+    }
+    
+    $createAccessTokenSplatParams = @{
+        Uri             = "https://login.microsoftonline.com/$($actionContext.Configuration.EntraIDTenantID)/oauth2/v2.0/token/"
+        Headers         = $headers
+        Method          = "POST"
+        ContentType     = "application/x-www-form-urlencoded"
+        UseBasicParsing = $true
+        Body            = $createAccessTokenBody
+        Verbose         = $false
+        ErrorAction     = "Stop"
+    }
+    
+    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    #endregion Create access token
+    
+    #region Create headers
+    $actionMessage = "creating headers"
+    
+    $headers = @{
+        "Accept"          = "application/json"
+        "Content-Type"    = "application/json;charset=utf-8"
+        "Mwp-Api-Version" = "1.0"
+    }
+    
+    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+
+    # Add Authorization after printing splat
+    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    #endregion Create headers
+
+    #region Get Personas
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/personas
+    $actionMessage = "querying personas"
+
+    $getKPNLisaPersonasSplatParams = @{
+        Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/personas"
+        Method      = "GET"
+        Verbose     = $false
+        ErrorAction = "Stop"
+    }
+
+    Write-Verbose "SplatParams: $($getKPNLisaPersonasSplatParams | ConvertTo-Json)"
+
+    # Add header after printing splat
+    $getKPNLisaPersonasSplatParams['Headers'] = $headers
+
+    $getKPNLisaPersonasResponse = $null
+    $getKPNLisaPersonasResponse = Invoke-RestMethod @getKPNLisaPersonasSplatParams
+    $kpnLisaPersonas = $getKPNLisaPersonasResponse
+
+    Write-Information "Queried personas. Result count: $(($kpnLisaPersonas | Measure-Object).Count)"
+    #endregion Get Personas
+
+    #region Get Personamembers
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/personas/{identifier}/members
+    $actionMessage = "querying Kpn Lisa Persona Members"
+    foreach ($kpnLisaPersona in $kpnLisaPersonas) {  
+        $kpnLisaPersonaMembers = [System.Collections.ArrayList]@()
+
+        $getKPNLisaPersonaMembersSplatParams = @{
+            Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/personas/$($kpnLisaPersona.id)/members"
+            Method      = "GET"
+            Verbose     = $false
+            ErrorAction = "Stop"
+        }
+
+        Write-Verbose "SplatParams: $($getKPNLisaPersonaMembersSplatParams | ConvertTo-Json)"
+
+        # Add header after printing splat
+        $getKPNLisaPersonaMembersSplatParams['Headers'] = $headers
+
+        $getKPNLisaPersonaMembersResponse = $null
+        $getKPNLisaPersonaMembersResponse = Invoke-RestMethod @getKPNLisaPersonaMembersSplatParams
+
+        if ($getKPNLisaPersonaMembersResponse -is [array]) {
+            [void]$kpnLisaPersonaMembers.AddRange($getKPNLisaPersonaMembersResponse)
+        }
+        else {
+            [void]$kpnLisaPersonaMembers.Add($getKPNLisaPersonaMembersResponse)
+        }
+        $numberOfAccounts = $(($kpnLisaPersonaMembers | Measure-Object).Count)
+
+        # Make sure the displayname has a value of max 100 char
+        if (-not([string]::IsNullOrEmpty($kpnLisaPersona.displayName))) {
+            $displayname = $($kpnLisaPersona.displayName).substring(0, [System.Math]::Min(100, $($kpnLisaPersona.displayName).Length))
+        }
+        else {
+            $displayname = $kpnLisaPersona.id
+        }
+        # Make sure the description has a value of max 100 char
+        if (-not([string]::IsNullOrEmpty($kpnLisaPersona.description))) {
+            $description = $($kpnLisaPersona.description).substring(0, [System.Math]::Min(100, $($kpnLisaPersona.description).Length))
+        }
+        else {
+            $description = $null
+        }
+
+        $permission = @{
+            PermissionReference = @{
+                Id = $kpnLisaPersona.id
+            }       
+            Description         = $description
+            DisplayName         = $displayName
+        }
+
+        # Batch permissions based on the amount of account references, 
+        # to make sure the output objects are not above the limit
+        $accountsBatchSize = 500
+        if ($numberOfAccounts -gt 0) {
+            $accountsBatchSize = 500
+            $batches = 0..($numberOfAccounts - 1) | Group-Object { [math]::Floor($_ / $accountsBatchSize ) }
+            foreach ($batch in $batches) {
+                $permission.AccountReferences = [array]($batch.Group | ForEach-Object {
+                    if($kpnLisaPersonaMembers[$_].objectId -eq '614d643b-d5ca-409c-9e12-954bb17eea6e'){
+                        @($kpnLisaPersonaMembers[$_])
+                    }
+                    if($kpnLisaPersonaMembers[$_].objectId -eq '06032afa-e378-4def-9c56-4e4276707399'){
+                        @($kpnLisaPersonaMembers[$_])
+                    }
+                    @($kpnLisaPersonaMembers[$_].objectId)
+                 })
+                Write-Output $permission
+            }
+        }
+    }
+    Write-Information 'Target permission import for [KPN Lisa Personas] completed'
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-KPNLisaError -ErrorObject $ex
+        $auditMessage = "Error $($actionMessage). Error: $($errorObj.FriendlyMessage)"
+        $warningMessage = "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error $($actionMessage). Error: $($ex.Exception.Message)"
+        $warningMessage = "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+
+    Write-Warning $warningMessage
+
+    # Required to write an error as uniqueness check doesn't show auditlog
+    Write-Error $auditMessage
+}

--- a/Permissions/personas/importPermission.ps1
+++ b/Permissions/personas/importPermission.ps1
@@ -107,7 +107,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -119,7 +119,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -136,7 +136,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaPersonasSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaPersonasSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaPersonasSplatParams['Headers'] = $headers
@@ -161,7 +161,7 @@ try {
             ErrorAction = "Stop"
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaPersonaMembersSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaPersonaMembersSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaPersonaMembersSplatParams['Headers'] = $headers

--- a/Permissions/personas/importPermission.ps1
+++ b/Permissions/personas/importPermission.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/personas/permissions.ps1
+++ b/Permissions/personas/permissions.ps1
@@ -105,7 +105,7 @@ try {
     
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -117,7 +117,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
@@ -134,7 +134,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaPersonasSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaPersonasSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaPersonasSplatParams['Headers'] = $headers

--- a/Permissions/personas/permissions.ps1
+++ b/Permissions/personas/permissions.ps1
@@ -111,9 +111,9 @@ try {
         ErrorAction     = "Stop"
     }
     
-    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -128,7 +128,7 @@ try {
     Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
-    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
     #endregion Create headers
 
     #region Get Personas
@@ -164,8 +164,7 @@ try {
             @{
                 displayName    = $displayName
                 identification = @{
-                    Id   = $_.id
-                    Name = $_.displayName
+                    Id = $_.id
                 }
             }
         )

--- a/Permissions/personas/permissions.ps1
+++ b/Permissions/personas/permissions.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/personas/revokePermission.ps1
+++ b/Permissions/personas/revokePermission.ps1
@@ -113,7 +113,7 @@ try {
     
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -125,7 +125,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
@@ -142,7 +142,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaPersonaMembersSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaPersonaMembersSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaPersonaMembersSplatParams['Headers'] = $headers
@@ -151,7 +151,7 @@ try {
     $getKPNLisaPersonaMembersResponse = Invoke-RestMethod @getKPNLisaPersonaMembersSplatParams
     $kpnLisaPersonaMemberObject = $getKPNLisaPersonaMembersResponse | Where-Object { $_.objectId -eq $($actionContext.References.Account) }
 
-    Write-Verbose "Queried persona member object. Result: $($kpnLisaPersonaMemberObject | ConvertTo-Json)"
+    Write-Information "Queried persona member object. Result: $($kpnLisaPersonaMemberObject | ConvertTo-Json)"
     #endregion Get Members of Persona
 
     if ([string]::IsNullOrEmpty($kpnLisaPersonaMemberObject)) {
@@ -170,7 +170,7 @@ try {
             ErrorAction = "Stop"
         }
 
-        Write-Verbose "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($revokePermissionSplatParams | ConvertTo-Json)"
 
         if (-Not($actionContext.DryRun -eq $true)) {
             # Add header after printing splat

--- a/Permissions/personas/revokePermission.ps1
+++ b/Permissions/personas/revokePermission.ps1
@@ -7,14 +7,6 @@ $actionContext.DryRun = $false
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/Permissions/personas/revokePermission.ps1
+++ b/Permissions/personas/revokePermission.ps1
@@ -3,7 +3,7 @@
 # Revoke persona from account
 # PowerShell V2
 #################################################
-
+$actionContext.DryRun = $false
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
@@ -119,9 +119,9 @@ try {
         ErrorAction     = "Stop"
     }
     
-    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -136,7 +136,7 @@ try {
     Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
-    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
     #endregion Create headers
 
     #region Get Persona Members
@@ -168,7 +168,7 @@ try {
     else {
         #region Remove account from persona
         # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: DELETE /api/Personas/{identifier}/members/{memberId}
-        $actionMessage = "revoking persona [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
+        $actionMessage = "revoking persona [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
 
         $revokePermissionSplatParams = @{
             Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/personas/$($actionContext.References.Permission.id)/members/$($kpnLisaPersonaMemberObject.id)"
@@ -188,12 +188,12 @@ try {
 
             $outputContext.AuditLogs.Add([PSCustomObject]@{
                     # Action  = "" # Optional
-                    Message = "Revoked persona [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Message = "Revoked persona [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                     IsError = $false
                 })
         }
         else {
-            Write-Warning "DryRun: Would revoke persona [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+            Write-Warning "DryRun: Would revoke persona [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
         }
         #endregion Remove account from persona
     }
@@ -214,7 +214,7 @@ catch {
     if ($auditMessage -like "*No member found*") {
         $outputContext.AuditLogs.Add([PSCustomObject]@{
                 # Action  = "" # Optional
-                Message = "Skipped revoking persona [$($actionContext.References.Permission.Name)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Reason: User is already no longer member of this persona."
+                Message = "Skipped revoking persona [$($actionContext.PermissionDisplayName)] with id [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Reason: User is already no longer member of this persona."
                 IsError = $false
             })
     }

--- a/README.md
+++ b/README.md
@@ -40,18 +40,15 @@
      - Create a **client secret** for your app.
    - Send the **Application (client) ID** to your KPN Modern Workplace contact, they will configure the required permissions.
 
-
 ## Remarks
 
 ### Workspace Profile
 
 - In KPN Lisa, a user can only have one WorkspaceProfile, so be careful not to add multiple profiles to a user. The revoke action will remove whatever workspaceProfile is active at the moment. This can result in unwanted behavior.
 
-
 ### Persona
 
 - A user can have only one Persona in KPN Lisa. Assigning more than one will return an error. Ensure your Business Rules assign only a single Persona per user.
-
 
 ### Manager Field in Field Mapping
 
@@ -98,6 +95,11 @@ _HelloID-Conn-Prov-Target-KPN-Lisa_ is a target connector that uses KPN's REST A
 | [/api/personas](https://mwpapi.kpnwerkplek.com/index.html)                                              | List personas (GET)                             |
 | [/api/Personas/{identifier}/members](https://mwpapi.kpnwerkplek.com/index.html)                         | Add persona to user (POST)                      |
 | [/api/Personas/{identifier}/members/{memberId}](https://mwpapi.kpnwerkplek.com/index.html)              | Remove persona from user (DELETE)               |
+| [/api/users/{identifier}/authentication](https://mwpapi.kpnwerkplek.com/index.html)                     | List authentication methods for user (GET)      |
+| [/api/users/{identifier}/authentication/phone](https://mwpapi.kpnwerkplek.com/index.html)               | Add phone authentication method (POST)          |
+| [/api/users/{identifier}/authentication/phone/{id}](https://mwpapi.kpnwerkplek.com/index.html)          | Remove phone authentication method (DELETE)     |
+| [/api/users/{identifier}/authentication/email](https://mwpapi.kpnwerkplek.com/index.html)               | Add email authentication method (POST)          |
+| [/api/users/{identifier}/authentication/email/{id}](https://mwpapi.kpnwerkplek.com/index.html)          | Remove email authentication method (DELETE)     |
 
 ### Actions
 
@@ -133,7 +135,6 @@ _HelloID-Conn-Prov-Target-KPN-Lisa_ is a target connector that uses KPN's REST A
 | `personas - grantPermission.ps1`               | Add a persona to a user account                                      |                                                        |
 | `personas - revokePermission.ps1`              | Remove a persona from a user account                                 |
 
-
 ## Getting Started
 
 ### Create an Application in Entra ID
@@ -168,6 +169,7 @@ For more information, see the [MWP API documentation](https://mwpapi.kpnwerkplek
 ### Provisioning PowerShell V2 connector
 
 #### Correlation Configuration
+
 The correlation configuration specifies which properties are used to match accounts in KPN Lia with users in HelloID.
 
 To properly set up the correlation:
@@ -182,11 +184,11 @@ To properly set up the correlation:
     | **Account Correlation Field** | `employeeId` |
 
 > Ensure the **Account Correlation Field** is supported by the MWP API's capabilities. Verify that your setup is supported by the [GET /api/users](https://mwpapi.kpnwerkplek.com/index.html).
-
 > [!TIP]
 > _For more information on correlation, please refer to our correlation [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems/correlation.html) pages_.
 
 #### Field mapping
+
 The field mapping can be imported by using the _fieldMapping.json_ file.
 
 ### Connection Settings
@@ -205,11 +207,13 @@ The following settings are required to connect to the KPN MWP API:
 | **Toggle debug logging**                                          | Displays debug logging when toggled. **Switch off in production**                                                                                                                                                                                                                                                                         | No        |
 
 ## Getting help
+>
 > [!TIP]
 > _For more information on how to configure a HelloID PowerShell connector, please refer to our [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems.html) pages_.
 
 > [!TIP]
->  _If you need help, feel free to ask questions on our [forum](https://forum.helloid.com)_.
+> _If you need help, feel free to ask questions on our [forum](https://forum.helloid.com)_.
 
 ## HelloID docs
-The official HelloID documentation can be found at: https://docs.helloid.com/
+
+The official HelloID documentation can be found at: <https://docs.helloid.com/>

--- a/README.md
+++ b/README.md
@@ -1,141 +1,71 @@
 # HelloID-Conn-Prov-Target-KPN-Lisa
 
-> [!WARNING]
-> This script is for the new powershell connector. Make sure to use the mapping and correlation keys like mentioned in this readme. For more information, please read our [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems.html)
-
 > [!IMPORTANT]
-> This repository contains only the connector and configuration code. The implementer is responsible for acquiring connection details such as the username, password, certificate, etc. You may also need to sign a contract or agreement with the supplier before implementing this connector. Please contact the client's application manager to coordinate the connector requirements.
+> This repository contains the connector and configuration code only. The implementer is responsible to acquire the connection details such as username, password, certificate, etc. You might even need to sign a contract or agreement with the supplier before implementing this connector. Please contact the client's application manager to coordinate the connector requirements.
 
 <p align="center">
-  <img src="https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-KPN-Lisa/blob/main/Logo.png?raw=true" alt="KPN Lisa Logo">
+  <img src="https://raw.githubusercontent.com/Tools4everBV/HelloID-Conn-Prov-Target-KPN-Lisa/refs/heads/main/Logo.png?raw=true" alt="KPN Lisa Logo">
 </p>
 
-## Table of Contents
+## Table of contents
 
 - [HelloID-Conn-Prov-Target-KPN-Lisa](#helloid-conn-prov-target-kpn-lisa)
-  - [Table of Contents](#table-of-contents)
-  - [Requirements](#requirements)
+  - [Table of contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Supported features](#supported-features)
+  - [Getting started](#getting-started)
+    - [HelloID Icon URL](#helloid-icon-url)
+    - [Requirements](#requirements)
+    - [Create an Application in Entra ID](#create-an-application-in-entra-id)
+    - [Set Up Permissions for KPN MWP API](#set-up-permissions-for-kpn-mwp-api)
+    - [Connection settings](#connection-settings)
+    - [Correlation configuration](#correlation-configuration)
+    - [Field mapping](#field-mapping)
+    - [Account Reference](#account-reference)
   - [Remarks](#remarks)
     - [Workspace Profile](#workspace-profile)
     - [Persona](#persona)
     - [Manager Field in Field Mapping](#manager-field-in-field-mapping)
-  - [Introduction](#introduction)
-    - [API Endpoints](#api-endpoints)
-    - [Actions](#actions)
-  - [Getting Started](#getting-started)
-    - [Create an Application in Entra ID](#create-an-application-in-entra-id)
-    - [Set Up Permissions for KPN MWP API](#set-up-permissions-for-kpn-mwp-api)
-    - [Provisioning PowerShell V2 connector](#provisioning-powershell-v2-connector)
-      - [Correlation Configuration](#correlation-configuration)
-      - [Field mapping](#field-mapping)
-    - [Connection Settings](#connection-settings)
+  - [Development resources](#development-resources)
+    - [API endpoints](#api-endpoints)
+    - [API documentation](#api-documentation)
   - [Getting help](#getting-help)
   - [HelloID docs](#helloid-docs)
 
-## Requirements
-
-1. **MWP API Credentials**: Refer to the KPN MWP API documentation for detailed instructions: [MWP API documentation](https://mwpapi.kpnwerkplek.com/index.html).
-   - Create an **App Registration** in Microsoft Entra ID.
-   - Create access credentials for your app:
-     - Create a **client secret** for your app.
-   - Send the **Application (client) ID** to your KPN Modern Workplace contact, they will configure the required permissions.
-
-## Remarks
-
-### Workspace Profile
-
-- In KPN Lisa, a user can only have one WorkspaceProfile, so be careful not to add multiple profiles to a user. The revoke action will remove whatever workspaceProfile is active at the moment. This can result in unwanted behavior.
-
-### Persona
-
-- A user can have only one Persona in KPN Lisa. Assigning more than one will return an error. Ensure your Business Rules assign only a single Persona per user.
-
-### Manager Field in Field Mapping
-
-- The `managerId` field is optional and represents the manager's ID for the user. This field is read-only.
-- **Note:** The `managerId` field uses a "None" mapping because the value is calculated within the scripts. The manager must exist in KPN Lisa and be managed by HelloID. Assign the **Account entitlement** to the manager before setting this field.
-
 ## Introduction
 
-_HelloID-Conn-Prov-Target-KPN-Lisa_ is a target connector that uses KPN's REST APIs to interact with data. Below is a list of API endpoints used in the connector.
+_HelloID-Conn-Prov-Target-KPN-Lisa_ is a target connector. KPN Lisa provides a set of REST APIs that allow you to programmatically interact with its data.
 
-### API Endpoints
+## Supported features
 
-| Endpoint                                                                                                | Description                                     |
-| ------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| [/api/users](https://mwpapi.kpnwerkplek.com/index.html)                                                 | Get users (GET)                                 |
-| [/api/users/{identifier}](https://mwpapi.kpnwerkplek.com/index.html)                                    | Get a specific user (GET)                       |
-| [/api/users](https://mwpapi.kpnwerkplek.com/index.html)                                                 | Create user (POST)                              |
-| [/api/users/{identifier}/bulk](https://mwpapi.kpnwerkplek.com/index.html)                               | Update user properties in bulk (PATCH)          |
-| [/api/users/{identifier}](https://mwpapi.kpnwerkplek.com/index.html)                                    | Delete user (DELETE)                            |
-| [/api/users/{identifier}/manager](https://mwpapi.kpnwerkplek.com/index.html)                            | Get manager of user (GET)                       |
-| [/api/users/{identifier}/manager](https://mwpapi.kpnwerkplek.com/index.html)                            | Update manager of user (PUT)                    |
-| [/api/users/{identifier}/manager](https://mwpapi.kpnwerkplek.com/index.html)                            | Delete manager of user (DELETE)                 |
-| [/api/groups](https://mwpapi.kpnwerkplek.com/index.html)                                                | List groups (GET)                               |
-| [/api/users/{identifier}/groups](https://mwpapi.kpnwerkplek.com/index.html)                             | Add member to group (POST)                      |
-| [/api/users/{identifier}/groups/{groupidentifier}](https://mwpapi.kpnwerkplek.com/index.html)           | Remove member from group (DELETE)               |
-| [/api/licenses](https://mwpapi.kpnwerkplek.com/index.html)                                              | List licenses (GET)                             |
-| [/api/users/{identifier}/licenses](https://mwpapi.kpnwerkplek.com/index.html)                           | Add license to user (POST)                      |
-| [/api/users/{identifier}/licenses/{skuId}](https://mwpapi.kpnwerkplek.com/index.html)                   | Remove license from user (DELETE)               |
-| [/api/teams](https://mwpapi.kpnwerkplek.com/index.html)                                                 | List teams (GET)                                |
-| [/api/users/{identifier}/teams](https://mwpapi.kpnwerkplek.com/index.html)                              | Add team to user (POST)                         |
-| [/api/users/{identifier}/teams/{memberId}](https://mwpapi.kpnwerkplek.com/index.html)                   | Remove team from user (DELETE)                  |
-| [/api/lisaroles](https://mwpapi.kpnwerkplek.com/index.html)                                             | List lisa roles (GET)                           |
-| [/api/users/{identifier}/lisaroles](https://mwpapi.kpnwerkplek.com/index.html)                          | Add lisa role to user (POST)                    |
-| [/api/users/{identifier}/lisaroles{roleId}](https://mwpapi.kpnwerkplek.com/index.html)                  | Remove lisa role from user (DELETE)             |
-| [/api/licenseprofiles](https://mwpapi.kpnwerkplek.com/index.html)                                       | List license profiles (GET)                     |
-| [/api/users/{identifier}/licenseprofiles](https://mwpapi.kpnwerkplek.com/index.html)                    | Add license profile to user (POST)              |
-| [/api/users/{identifier}/licenseprofiles/{licenseProfileId}](https://mwpapi.kpnwerkplek.com/index.html) | Remove license profile from user (DELETE)       |
-| [/api/authorizationprofiles](https://mwpapi.kpnwerkplek.com/index.html)                                 | List authorization profiles (GET)               |
-| [/api/users/{identifier}/authorizationprofiles](https://mwpapi.kpnwerkplek.com/index.html)              | Add authorization profile to user (POST)        |
-| [/api/AuthorizationProfiles/{identifier}/members/{memberId}](https://mwpapi.kpnwerkplek.com/index.html) | Remove authorization profile from user (DELETE) |
-| [/api/workspaceprofiles](https://mwpapi.kpnwerkplek.com/index.html)                                     | List workspace profiles (GET)                   |
-| [/api/users/{identifier}/workspaceprofiles](https://mwpapi.kpnwerkplek.com/index.html)                  | Add workspace profile to user (POST)            |
-| [/api/users/{identifier}/workspaceprofiles](https://mwpapi.kpnwerkplek.com/index.html)                  | Remove workspace profile from user (DELETE)     |
-| [/api/personas](https://mwpapi.kpnwerkplek.com/index.html)                                              | List personas (GET)                             |
-| [/api/Personas/{identifier}/members](https://mwpapi.kpnwerkplek.com/index.html)                         | Add persona to user (POST)                      |
-| [/api/Personas/{identifier}/members/{memberId}](https://mwpapi.kpnwerkplek.com/index.html)              | Remove persona from user (DELETE)               |
-| [/api/users/{identifier}/authentication](https://mwpapi.kpnwerkplek.com/index.html)                     | List authentication methods for user (GET)      |
-| [/api/users/{identifier}/authentication/phone](https://mwpapi.kpnwerkplek.com/index.html)               | Add phone authentication method (POST)          |
-| [/api/users/{identifier}/authentication/phone/{id}](https://mwpapi.kpnwerkplek.com/index.html)          | Remove phone authentication method (DELETE)     |
-| [/api/users/{identifier}/authentication/email](https://mwpapi.kpnwerkplek.com/index.html)               | Add email authentication method (POST)          |
-| [/api/users/{identifier}/authentication/email/{id}](https://mwpapi.kpnwerkplek.com/index.html)          | Remove email authentication method (DELETE)     |
+The following features are available:
 
-### Actions
+| Feature                                   | Supported | Actions                                 | Remarks                      |
+| ----------------------------------------- | --------- | --------------------------------------- | ---------------------------- |
+| **Account Lifecycle**                     | ✅         | Create, Update, Enable, Disable, Delete |                              |
+| **Permissions**                           | ✅         | Retrieve, Grant, Revoke                 | Only `Groups` and `Personas` |
+| **Resources**                             | ❌         | -                                       |                              |
+| **Entitlement Import: Accounts**          | ✅         | -                                       |                              |
+| **Entitlement Import: Permissions**       | ✅         | -                                       |                              |
+| **Governance Reconciliation Resolutions** | ✅         | -                                       |                              |
 
-| Action                                         | Description                                                          | Comment                                                |
-| ---------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------ |
-| `create.ps1`                                   | Create (or update) and correlate a user account                      |                                                        |
-| `enable.ps1`                                   | Enable a user account                                                |                                                        |
-| `update.ps1`                                   | Update a user account                                                |                                                        |
-| `disable.ps1`                                  | Disable a user account                                               |                                                        |
-| `delete.ps1`                                   | Delete a user account                                                | Be cautious; deleted users cannot be restored.         |
-| `groups - permissions.ps1`                     | Retrieve all groups and provide them as entitlements                 |                                                        |
-| `groups - grantPermission.ps1`                 | Add a group to a user account                                        |                                                        |
-| `groups - revokePermission.ps1`                | Remove a group from a user account                                   |                                                        |
-| `licenses - permissions.ps1`                   | Retrieve all licenses and provide them as entitlements               |                                                        |
-| `licenses - grantPermission.ps1`               | Assign a license to a user account                                   |                                                        |
-| `licenses - revokePermission.ps1`              | Remove a license from a user account                                 |                                                        |
-| `teams - permissions.ps1`                      | Retrieve all teams and provide them as entitlements                  |                                                        |
-| `teams - grantPermission.ps1`                  | Add a user to a team                                                 |                                                        |
-| `teams - revokePermission.ps1`                 | Remove a user from a team                                            |                                                        |
-| `lisaroles - permissions.ps1`                  | Retrieve all Lisa roles and provide them as entitlements             |                                                        |
-| `lisaroles - grantPermission.ps1`              | Assign a Lisa role to a user                                         |                                                        |
-| `lisaroles - revokePermission.ps1`             | Remove a Lisa role from a user                                       |                                                        |
-| `licenseprofiles - permissions.ps1`            | Retrieve all license profiles and provide them as entitlements       |                                                        |
-| `licenseprofiles - grantPermission.ps1`        | Assign a license profile to a user                                   |                                                        |
-| `licenseprofiles - revokePermission.ps1`       | Remove a license profile from a user                                 |                                                        |
-| `authorizationprofiles - permissions.ps1`      | Retrieve all authorization profiles and provide them as entitlements |                                                        |
-| `authorizationprofiles - grantPermission.ps1`  | Add an authorization profile to a user account                       |                                                        |
-| `authorizationprofiles - revokePermission.ps1` | Remove an authorization profile from a user                          |                                                        |
-| `workspaceprofiles - permissions.ps1`          | Retrieve all workspace profiles and provide them as entitlements     |                                                        |
-| `workspaceprofiles - grantPermission.ps1`      | Assign a workspace profile to a user                                 |                                                        |
-| `workspaceprofiles - revokePermission.ps1`     | Remove a workspace profile from a user account                       | Be cautious; this removes the active WorkspaceProfile. |
-| `personas - permissions.ps1`                   | Retrieve all personas and provide them as entitlements               |                                                        |
-| `personas - grantPermission.ps1`               | Add a persona to a user account                                      |                                                        |
-| `personas - revokePermission.ps1`              | Remove a persona from a user account                                 |
+## Getting started
 
-## Getting Started
+### HelloID Icon URL
+
+URL of the icon used for the HelloID Provisioning target system.
+
+```
+https://raw.githubusercontent.com/Tools4everBV/HelloID-Conn-Prov-Target-KPN-Lisa/refs/heads/main/Logo.png
+```
+
+### Requirements
+
+- **MWP API Credentials**: Refer to the KPN MWP API documentation for detailed instructions: [MWP API documentation](https://mwpapi.kpnwerkplek.com/index.html).
+  - Create an **App Registration** in Microsoft Entra ID.
+  - Create access credentials for your app:
+    - Create a **client secret** for your app.
+  - Send the **Application (client) ID** to your KPN Modern Workplace contact, they will configure the required permissions.
 
 ### Create an Application in Entra ID
 
@@ -166,54 +96,111 @@ Refer to [Microsoft's Quickstart guide](https://learn.microsoft.com/en-us/entra/
 
 For more information, see the [MWP API documentation](https://mwpapi.kpnwerkplek.com/index.html).
 
-### Provisioning PowerShell V2 connector
-
-#### Correlation Configuration
-
-The correlation configuration specifies which properties are used to match accounts in KPN Lia with users in HelloID.
-
-To properly set up the correlation:
-
-1. Open the `Correlation` tab.
-
-2. Specify the following configuration:
-
-    | Setting                       | Value        |
-    | ----------------------------- | ------------ |
-    | **Person Correlation Field**  | `ExternalId` |
-    | **Account Correlation Field** | `employeeId` |
-
-> Ensure the **Account Correlation Field** is supported by the MWP API's capabilities. Verify that your setup is supported by the [GET /api/users](https://mwpapi.kpnwerkplek.com/index.html).
-> [!TIP]
-> _For more information on correlation, please refer to our correlation [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems/correlation.html) pages_.
-
-#### Field mapping
-
-The field mapping can be imported by using the _fieldMapping.json_ file.
-
-### Connection Settings
+### Connection settings
 
 The following settings are required to connect to the KPN MWP API:
 
 | Setting                                                           | Description                                                                                                                                                                                                                                                                                                                               | Mandatory |
 | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | **Entra ID App Registration Directory (tenant) ID**               | The ID to the Tenant in Microsoft Entra ID.                                                                                                                                                                                                                                                                                               | Yes       |
-| **Entra ID App Registration Application (client) ID**             | The ID to the App Registration in Microsoft Entra ID .                                                                                                                                                                                                                                                                                    | Yes       |
+| **Entra ID App Registration Application (client) ID**             | The ID to the App Registration in Microsoft Entra ID.                                                                                                                                                                                                                                                                                     | Yes       |
 | **Entra ID App Registration Client Secret**                       | The Client Secret to the App Registration in Microsoft Entra ID.                                                                                                                                                                                                                                                                          | Yes       |
 | **KPN MWP Scope**                                                 | The scope used when creating the access token. Choose from the following based on your environment: <br> - **Development:** `https://kpnwp.onmicrosoft.com/kpnmwpdmwpapi/.default` <br> - **Test:** `https://kpnwp.onmicrosoft.com/kpnmwptmwpapi/.default` <br> - **Production:** `https://kpnwp.onmicrosoft.com/kpnmwppmwpapi/.default`. | Yes       |
 | **MWP API BaseUrl**                                               | The URL of the MWP API service.                                                                                                                                                                                                                                                                                                           | Yes       |
 | **Set manager when an account is created**                        | When toggled, this connector will calculate and set the manager upon creating an account.                                                                                                                                                                                                                                                 | No        |
 | **Update manager when the account update operation is performed** | When toggled, this connector will calculate and set the manager upon updating an account.                                                                                                                                                                                                                                                 | No        |
-| **Toggle debug logging**                                          | Displays debug logging when toggled. **Switch off in production**                                                                                                                                                                                                                                                                         | No        |
+
+### Correlation configuration
+
+The correlation configuration is used to specify which properties will be used to match an existing account within KPN Lisa to a person in HelloID.
+
+| Setting                       | Value                             |
+| ----------------------------- | --------------------------------- |
+| **Enable correlation**        | `True`                            |
+| **Person correlation field**  | `PersonContext.Person.ExternalId` |
+| **Account correlation field** | `employeeId`                      |
+
+> Ensure the **Account Correlation Field** is supported by the MWP API's capabilities. Verify that your setup is supported by the [GET /api/users](https://mwpapi.kpnwerkplek.com/index.html).
+
+> [!TIP]
+> _For more information on correlation, please refer to our correlation [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems/correlation.html) pages_.
+
+### Field mapping
+
+The field mapping can be imported by using the _fieldMapping.json_ file.
+
+### Account Reference
+
+The account reference is populated with the `id` property from KPN Lisa.
+
+## Remarks
+
+### Workspace Profile
+
+- In KPN Lisa, a user can only have one WorkspaceProfile, so be careful not to add multiple profiles to a user. The revoke action will remove whatever workspaceProfile is active at the moment. This can result in unwanted behavior.
+
+### Persona
+
+- A user can have only one Persona in KPN Lisa. Assigning more than one will return an error. Ensure your Business Rules assign only a single Persona per user.
+
+### Manager Field in Field Mapping
+
+- The `managerId` field is optional and represents the manager's ID for the user. This field is read-only.
+- **Note:** The `managerId` field uses a "None" mapping because the value is calculated within the scripts. The manager must exist in KPN Lisa and be managed by HelloID. Assign the **Account entitlement** to the manager before setting this field.
+
+## Development resources
+
+### API endpoints
+
+The following endpoints are used by the connector:
+
+| Endpoint                                                     | HTTP Method      | Description                            |
+| ------------------------------------------------------------ | ---------------- | -------------------------------------- |
+| `/api/users`                                                 | GET              | Get users                              |
+| `/api/users/{identifier}`                                    | GET              | Get a specific user                    |
+| `/api/users`                                                 | POST             | Create user                            |
+| `/api/users/{identifier}/bulk`                               | PATCH            | Update user properties in bulk         |
+| `/api/users/{identifier}`                                    | DELETE           | Delete user                            |
+| `/api/users/{identifier}/manager`                            | GET, PUT, DELETE | Get, update, or delete manager of user |
+| `/api/groups`                                                | GET              | List groups                            |
+| `/api/users/{identifier}/groups`                             | POST             | Add member to group                    |
+| `/api/users/{identifier}/groups/{groupidentifier}`           | DELETE           | Remove member from group               |
+| `/api/licenses`                                              | GET              | List licenses                          |
+| `/api/users/{identifier}/licenses`                           | POST             | Add license to user                    |
+| `/api/users/{identifier}/licenses/{skuId}`                   | DELETE           | Remove license from user               |
+| `/api/teams`                                                 | GET              | List teams                             |
+| `/api/users/{identifier}/teams`                              | POST             | Add team to user                       |
+| `/api/users/{identifier}/teams/{memberId}`                   | DELETE           | Remove team from user                  |
+| `/api/lisaroles`                                             | GET              | List lisa roles                        |
+| `/api/users/{identifier}/lisaroles`                          | POST             | Add lisa role to user                  |
+| `/api/users/{identifier}/lisaroles/{roleId}`                 | DELETE           | Remove lisa role from user             |
+| `/api/licenseprofiles`                                       | GET              | List license profiles                  |
+| `/api/users/{identifier}/licenseprofiles`                    | POST             | Add license profile to user            |
+| `/api/users/{identifier}/licenseprofiles/{licenseProfileId}` | DELETE           | Remove license profile from user       |
+| `/api/authorizationprofiles`                                 | GET              | List authorization profiles            |
+| `/api/users/{identifier}/authorizationprofiles`              | POST             | Add authorization profile to user      |
+| `/api/AuthorizationProfiles/{identifier}/members/{memberId}` | DELETE           | Remove authorization profile from user |
+| `/api/workspaceprofiles`                                     | GET              | List workspace profiles                |
+| `/api/users/{identifier}/workspaceprofiles`                  | POST             | Add workspace profile to user          |
+| `/api/users/{identifier}/workspaceprofiles`                  | DELETE           | Remove workspace profile from user     |
+| `/api/personas`                                              | GET              | List personas                          |
+| `/api/Personas/{identifier}/members`                         | POST             | Add persona to user                    |
+| `/api/Personas/{identifier}/members/{memberId}`              | DELETE           | Remove persona from user               |
+| `/api/users/{identifier}/authentication`                     | GET              | List authentication methods for user   |
+| `/api/users/{identifier}/authentication/phone`               | POST             | Add phone authentication method        |
+| `/api/users/{identifier}/authentication/phone/{id}`          | DELETE           | Remove phone authentication method     |
+| `/api/users/{identifier}/authentication/email`               | POST             | Add email authentication method        |
+| `/api/users/{identifier}/authentication/email/{id}`          | DELETE           | Remove email authentication method     |
+
+### API documentation
+
+For more information, see the [MWP API documentation](https://mwpapi.kpnwerkplek.com/index.html).
 
 ## Getting help
->
+
 > [!TIP]
 > _For more information on how to configure a HelloID PowerShell connector, please refer to our [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems.html) pages_.
 
-> [!TIP]
-> _If you need help, feel free to ask questions on our [forum](https://forum.helloid.com)_.
-
 ## HelloID docs
 
-The official HelloID documentation can be found at: <https://docs.helloid.com/>
+The official HelloID documentation can be found at: [https://docs.helloid.com/](https://docs.helloid.com/)

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ The following features are available:
 | Feature                                   | Supported | Actions                                 | Remarks                      |
 | ----------------------------------------- | --------- | --------------------------------------- | ---------------------------- |
 | **Account Lifecycle**                     | ✅         | Create, Update, Enable, Disable, Delete |                              |
-| **Permissions**                           | ✅         | Retrieve, Grant, Revoke                 | Only `Groups` and `Personas` |
+| **Permissions**                           | ✅         | Retrieve, Grant, Revoke                 |                              |
 | **Resources**                             | ❌         | -                                       |                              |
 | **Entitlement Import: Accounts**          | ✅         | -                                       |                              |
-| **Entitlement Import: Permissions**       | ✅         | -                                       |                              |
+| **Entitlement Import: Permissions**       | ✅         | -                                       | Only `Groups` and `Personas` |
 | **Governance Reconciliation Resolutions** | ✅         | -                                       |                              |
 
 ## Getting started

--- a/configuration.json
+++ b/configuration.json
@@ -85,15 +85,5 @@
             "description": "",
             "required": false
         }
-    },
-    {
-        "key": "isDebug",
-        "type": "checkbox",
-        "defaultValue": false,
-        "templateOptions": {
-            "label": "Toggle debug logging",
-            "description": "When toggled, debug logging will be displayed",
-            "required": false
-        }
     }
 ]

--- a/create.ps1
+++ b/create.ps1
@@ -144,7 +144,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -156,7 +156,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -177,7 +177,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
 
     # Add Headers after printing splat
     $getKPNLisaAccountSplatParams['Headers'] = $headers
@@ -186,7 +186,7 @@ try {
     $getKPNLisaAccountResponse = Invoke-RestMethod @getKPNLisaAccountSplatParams
     $correlatedAccount = $getKPNLisaAccountResponse.Value
         
-    Write-Verbose "Queried account where [$($correlationField)] = [$($correlationValue)]. Result: $($correlatedAccount  | ConvertTo-Json)"
+    Write-Information "Queried account where [$($correlationField)] = [$($correlationValue)]. Result: $($correlatedAccount  | ConvertTo-Json)"
     #endregion Get account
 
     #region Calulate action
@@ -225,7 +225,7 @@ try {
                 ErrorAction = "Stop"
             }
 
-            Write-Verbose "SplatParams: $($createAccountSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($createAccountSplatParams | ConvertTo-Json)"
 
             if (-Not($actionContext.DryRun -eq $true)) {
                 # Add Headers after printing splat
@@ -271,7 +271,7 @@ try {
                 ErrorAction = "Stop"
             }
 
-            Write-Verbose "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
 
             if (-Not($actionContext.DryRun -eq $true)) {
                 # Add Headers after printing splat
@@ -317,7 +317,7 @@ try {
                             ErrorAction = "Stop"
                         }
 
-                        Write-Verbose "SplatParams: $($setManagerSplatParams | ConvertTo-Json)"
+                        Write-Information "SplatParams: $($setManagerSplatParams | ConvertTo-Json)"
 
                         if (-Not($actionContext.DryRun -eq $true)) {
                             # Add Headers after printing splat

--- a/create.ps1
+++ b/create.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/delete.ps1
+++ b/delete.ps1
@@ -135,7 +135,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -147,7 +147,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -167,7 +167,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaAccountSplatParams['Headers'] = $headers
@@ -176,7 +176,7 @@ try {
     $getKPNLisaAccountResponse = Invoke-RestMethod @getKPNLisaAccountSplatParams
     $correlatedAccount = $getKPNLisaAccountResponse
         
-    Write-Verbose "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
+    Write-Information "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
     #endregion Get account
 
     #region Calulate action
@@ -207,7 +207,7 @@ try {
                 ErrorAction = "Stop"
             }
 
-            Write-Verbose "SplatParams: $($deleteAccountSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($deleteAccountSplatParams | ConvertTo-Json)"
 
             if (-Not($actionContext.DryRun -eq $true)) {
                 # Add header after printing splat

--- a/delete.ps1
+++ b/delete.ps1
@@ -92,20 +92,24 @@ function Convert-StringToBoolean($obj) {
 try {
     #region account
     # Define account object
-    $account = [PSCustomObject]$actionContext.Data.PsObject.Copy()
+    if ($actionContext.Data -ne $null) {
+        $account = [PSCustomObject]$actionContext.Data.PsObject.Copy()
+
+        # Remove properties of account object with null-values
+        $account.PsObject.Properties | ForEach-Object {
+            # Remove properties with null-values
+            if ($_.Value -eq $null) {
+                $account.PsObject.Properties.Remove("$($_.Name)")
+            }
+        }
+        # Convert the properties of account object containing "TRUE" or "FALSE" to boolean
+        $account = Convert-StringToBoolean $account
+    }
 
     # Define properties to query
-    $accountPropertiesToQuery = @("id") + $account.PsObject.Properties.Name | Select-Object -Unique
-
-    # Remove properties of account object with null-values
-    $account.PsObject.Properties | ForEach-Object {
-        # Remove properties with null-values
-        if ($_.Value -eq $null) {
-            $account.PsObject.Properties.Remove("$($_.Name)")
-        }
-    }
-    # Convert the properties of account object containing "TRUE" or "FALSE" to boolean
-    $account = Convert-StringToBoolean $account
+    # Automatically replaced by HelloID for compatibility with release 2025.04
+    # $accountPropertiesToQuery = @("id") + $account.PsObject.Properties.Name | Select-Object -Unique
+    $accountPropertiesToQuery = @("id") + $outputContext.Data.PsObject.Properties.Name | Select-Object -Unique
     #endRegion account
 
     #region Verify account reference

--- a/delete.ps1
+++ b/delete.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/disable.ps1
+++ b/disable.ps1
@@ -134,7 +134,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expires_in | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -146,7 +146,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -166,7 +166,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaAccountSplatParams['Headers'] = $headers
@@ -175,7 +175,7 @@ try {
     $getKPNLisaAccountResponse = Invoke-RestMethod @getKPNLisaAccountSplatParams
     $correlatedAccount = $getKPNLisaAccountResponse
         
-    Write-Verbose "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
+    Write-Information "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
     #endregion Get account
 
     #region Calulate action
@@ -228,7 +228,7 @@ try {
                 $accountChangedPropertiesObject.NewValues.$($accountNewProperty.Name) = $accountNewProperty.Value
             }
 
-            Write-Verbose "Changed properties: $($accountChangedPropertiesObject | ConvertTo-Json)"
+            Write-Information "Changed properties: $($accountChangedPropertiesObject | ConvertTo-Json)"
 
             $actionAccount = "Update"
         }
@@ -236,7 +236,7 @@ try {
             $actionAccount = "NoChanges"
         }            
 
-        Write-Verbose "Compared current account to mapped properties. Result: $actionAccount"
+        Write-Information "Compared current account to mapped properties. Result: $actionAccount"
     }
     elseif (($correlatedAccount | Measure-Object).count -eq 0) {
         $actionAccount = "NotFound"
@@ -276,7 +276,7 @@ try {
                 ErrorAction = "Stop"
             }
 
-            Write-Verbose "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
 
             if (-Not($actionContext.DryRun -eq $true)) {
                 # Add header after printing splat

--- a/disable.ps1
+++ b/disable.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/enable.ps1
+++ b/enable.ps1
@@ -134,7 +134,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -146,7 +146,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -166,7 +166,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaAccountSplatParams['Headers'] = $headers
@@ -175,7 +175,7 @@ try {
     $getKPNLisaAccountResponse = Invoke-RestMethod @getKPNLisaAccountSplatParams
     $correlatedAccount = $getKPNLisaAccountResponse
         
-    Write-Verbose "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
+    Write-Information "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
     #endregion Get account
 
     #region Calulate action
@@ -228,7 +228,7 @@ try {
                 $accountChangedPropertiesObject.NewValues.$($accountNewProperty.Name) = $accountNewProperty.Value
             }
 
-            Write-Verbose "Changed properties: $($accountChangedPropertiesObject | ConvertTo-Json)"
+            Write-Information "Changed properties: $($accountChangedPropertiesObject | ConvertTo-Json)"
 
             $actionAccount = "Update"
         }
@@ -236,7 +236,7 @@ try {
             $actionAccount = "NoChanges"
         }            
 
-        Write-Verbose "Compared current account to mapped properties. Result: $actionAccount"
+        Write-Information "Compared current account to mapped properties. Result: $actionAccount"
     }
     elseif (($correlatedAccount | Measure-Object).count -eq 0) {
         $actionAccount = "NotFound"
@@ -276,7 +276,7 @@ try {
                 ErrorAction = "Stop"
             }
 
-            Write-Verbose "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
 
             if (-Not($actionContext.DryRun -eq $true)) {
                 # Add header after printing splat

--- a/enable.ps1
+++ b/enable.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/fieldMapping.json
+++ b/fieldMapping.json
@@ -114,7 +114,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -142,7 +142,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": true,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -170,7 +170,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -198,7 +198,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": true,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -226,7 +226,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -262,7 +262,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -290,7 +290,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": true,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -363,7 +363,7 @@
                     "MappingMode": "None",
                     "Value": "\"\"",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -391,7 +391,7 @@
                     "MappingMode": "None",
                     "Value": "null",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -407,7 +407,7 @@
                     "MappingMode": "Complex",
                     "Value": "\"// Mapping logic to generate the BusinessPhones as a string collection.\\r\\nfunction generateBusinessPhones() {\\r\\n    const businessMobile = Person.Contact.Business.Phone.Mobile;\\r\\n\\r\\n    let businessPhones = [];\\r\\n\\r\\n    if (businessMobile) {\\r\\n        businessPhones.push(businessMobile);\\r\\n    }\\r\\n\\r\\n    return businessPhones;\\r\\n}\\r\\n\\r\\ngenerateBusinessPhones();\"",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -423,7 +423,7 @@
                     "MappingMode": "None",
                     "Value": "\"\"",
                     "UsedInNotifications": true,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         },
@@ -451,7 +451,7 @@
                     "MappingMode": "None",
                     "Value": "\"\"",
                     "UsedInNotifications": false,
-                    "StoreInAccountData": true
+                    "StoreInAccountData": false
                 }
             ]
         }

--- a/import.ps1
+++ b/import.ps1
@@ -121,7 +121,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -133,7 +133,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -159,7 +159,7 @@ try {
             $getKPNLisaUsersSplatParams.Body.SkipToken = $getKPNLisaUsersResponse.'nextLink'
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaUsersSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaUsersSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaUsersSplatParams['Headers'] = $headers

--- a/import.ps1
+++ b/import.ps1
@@ -1,0 +1,227 @@
+#################################################
+# HelloID-Conn-Prov-Target-KPN-Lisa-Import
+# Correlate to account
+# PowerShell V2
+#################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Resolve-KPNLisaError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+
+            $errorObjectConverted = $ErrorObject.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop
+
+            if ($null -ne $errorObjectConverted.Error) {
+                if ($null -ne $errorObjectConverted.Error.Message) {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error.Message
+
+                    if ($null -ne $errorObjectConverted.Error.Code) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Error code: $($errorObjectConverted.Error.Code)"
+                    }
+
+                    if ($null -ne $errorObjectConverted.ErrorDetails) { 
+                        $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Additional details: $($errorObjectConverted.ErrorDetails | ConvertTo-Json)"
+                    }
+                }
+                else {
+                    $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error
+                }
+            }
+            else {
+                $httpErrorObj.FriendlyMessage = $ErrorObject
+            }
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+        }
+        Write-Output $httpErrorObj
+    }
+}
+
+function Convert-StringToBoolean($obj) {
+    foreach ($property in $obj.PSObject.Properties) {
+        $value = $property.Value
+        if ($value -is [string]) {
+            try {
+                $obj.$($property.Name) = [System.Convert]::ToBoolean($value)
+            }
+            catch {
+                # Handle cases where conversion fails
+                $obj.$($property.Name) = $value
+            }
+        }
+    }
+    return $obj
+}
+#endregion functions
+
+try {
+    Write-Information 'Starting target account import'
+
+    # Define properties to query
+    $importFields = $($actionContext.ImportFields)
+    $importFields = $importFields -replace '\..*', ''
+
+    # Add mandatory fields for HelloID to query and return
+    if ('id' -notin $importFields) { $importFields += 'id' }
+    if ('accountEnabled' -notin $importFields) { $importFields += 'accountEnabled ' }
+    if ('displayName' -notin $importFields) { $importFields += 'displayName' }
+    if ('userPrincipalName' -notin $importFields) { $importFields += 'userPrincipalName' }
+
+    # Convert to a ',' string
+    $fields = $importFields -join ','
+    Write-Information "Querying fields [$fields]"
+
+    #region Create access token
+    $actionMessage = "creating access token"
+    
+    $createAccessTokenBody = @{
+        grant_type    = "client_credentials"
+        client_id     = $actionContext.Configuration.EntraIDAppId
+        client_secret = $actionContext.Configuration.EntraIDAppSecret
+        scope         = $actionContext.Configuration.KPNMWPScope
+    }
+    
+    $createAccessTokenSplatParams = @{
+        Uri             = "https://login.microsoftonline.com/$($actionContext.Configuration.EntraIDTenantID)/oauth2/v2.0/token/"
+        Headers         = $headers
+        Method          = "POST"
+        ContentType     = "application/x-www-form-urlencoded"
+        UseBasicParsing = $true
+        Body            = $createAccessTokenBody
+        Verbose         = $false
+        ErrorAction     = "Stop"
+    }
+    
+    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
+    
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    #endregion Create access token
+    
+    #region Create headers
+    $actionMessage = "creating headers"
+    
+    $headers = @{
+        "Accept"          = "application/json"
+        "Content-Type"    = "application/json;charset=utf-8"
+        "Mwp-Api-Version" = "1.0"
+    }
+    
+    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+
+    # Add Authorization after printing splat
+    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    #endregion Create headers
+
+    #region Get account
+    # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/users
+    $actionMessage = "querying accounts"
+
+    $existingAccounts = [System.Collections.ArrayList]@()
+    do {
+        $getKPNLisaUsersSplatParams = @{
+            Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users"
+            Method      = "GET"
+            Body        = @{
+                Top       = 999
+                SkipToken = $Null
+            }
+            Verbose     = $false
+            ErrorAction = "Stop"
+        }
+        if (-not[string]::IsNullOrEmpty($getKPNLisaUsersResponse.'nextLink')) {
+            $getKPNLisaUsersSplatParams.Body.SkipToken = $getKPNLisaUsersResponse.'nextLink'
+        }
+
+        Write-Verbose "SplatParams: $($getKPNLisaUsersSplatParams | ConvertTo-Json)"
+
+        # Add header after printing splat
+        $getKPNLisaUsersSplatParams['Headers'] = $headers
+
+        $getKPNLisaUsersResponse = $null
+        $getKPNLisaUsersResponse = Invoke-RestMethod @getKPNLisaUsersSplatParams
+
+        if ($getKPNLisaUsersResponse.Value -is [array]) {
+            [void]$existingAccounts.AddRange($getKPNLisaUsersResponse.Value)
+        }
+        else {
+            [void]$existingAccounts.Add($getKPNLisaUsersResponse.Value)
+        }
+    } while (-not[string]::IsNullOrEmpty($getKPNLisaUsersResponse.'nextLink'))
+
+    Write-Information "Queried users. Result count: $(($existingAccounts | Measure-Object).Count)"
+
+    # Map the imported data to the account field mappings
+    foreach ($account in $existingAccounts) {
+        # Make sure the DisplayName has a value
+        if ([string]::IsNullOrEmpty($account.displayName)) {
+            $account.displayName = $account.id
+        }
+        # Make sure the Username has a value
+        if ([string]::IsNullOrEmpty($account.userPrincipalName)) {
+            $account.userPrincipalName = $account.id
+        }
+        # Return the result
+        Write-Output @{
+            AccountReference = $account.id
+            DisplayName      = $account.displayName
+            UserName         = $account.userPrincipalName
+            Enabled          = $account.accountEnabled
+            Data             = $account
+        }
+    }
+
+    Write-Information 'Target account import completed'
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-KPNLisaError -ErrorObject $ex
+        $auditMessage = "Error $($actionMessage). Error: $($errorObj.FriendlyMessage)"
+        $warningMessage = "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error $($actionMessage). Error: $($ex.Exception.Message)"
+        $warningMessage = "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+
+    Write-Warning $warningMessage
+
+    # Required to write an error as uniqueness check doesn't show auditlog
+    Write-Error $auditMessage
+}

--- a/import.ps1
+++ b/import.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/uniquenessCheck.ps1
+++ b/uniquenessCheck.ps1
@@ -120,7 +120,7 @@ try {
     
     $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
     
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
     
     #region Create headers
@@ -132,7 +132,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
     
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
@@ -170,7 +170,7 @@ try {
             ErrorAction = "Stop"
         }
 
-        Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
+        Write-Information "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
 
         # Add header after printing splat
         $getKPNLisaAccountSplatParams['Headers'] = $headers
@@ -179,18 +179,18 @@ try {
         $getKPNLisaAccountResponse = Invoke-RestMethod @getKPNLisaAccountSplatParams
         $correlatedAccount = $getKPNLisaAccountResponse.Value
     
-        Write-Verbose "Queried account where [$($fieldToCheck.Name)] = [$($fieldToCheck.Value.accountValue)]. Result: $($correlatedAccount | ConvertTo-Json)"
+        Write-Information "Queried account where [$($fieldToCheck.Name)] = [$($fieldToCheck.Value.accountValue)]. Result: $($correlatedAccount | ConvertTo-Json)"
         #endregion Get account
 
         #region Check property uniqueness
         $actionMessage = "checking if property [$($fieldToCheck.Name)] with value [$($fieldToCheck.Value.accountValue)] is unique"
         if (($correlatedAccount | Measure-Object).count -gt 0) {
             if ($actionContext.Operation.ToLower() -ne "create" -and $correlatedAccount.id -eq $actionContext.References.Account) {
-                Write-Verbose "Person is using property [$($fieldToCheck.Name)] with value [$($fieldToCheck.Value.accountValue)] themselves."
+                Write-Information "Person is using property [$($fieldToCheck.Name)] with value [$($fieldToCheck.Value.accountValue)] themselves."
             }
             else {
-                Write-Verbose "Property [$($fieldToCheck.Name)] with value [$($fieldToCheck.Value.accountValue)] is not unique."
-                Write-Verbose "In use by: $($correlatedAccount | ConvertTo-Json)."
+                Write-Information "Property [$($fieldToCheck.Name)] with value [$($fieldToCheck.Value.accountValue)] is not unique."
+                Write-Information "In use by: $($correlatedAccount | ConvertTo-Json)."
                 [void]$outputContext.NonUniqueFields.Add($fieldToCheck.Name)
         
                 if (($fieldToCheck.Value.keepInSyncWith | Measure-Object).Count -ge 1) {
@@ -201,7 +201,7 @@ try {
             }
         }
         elseif (($correlatedAccount | Measure-Object).count -eq 0) {
-            Write-Verbose "Property [$($fieldToCheck.Name)] with value [$($fieldToCheck.Value.accountValue)] is unique."
+            Write-Information "Property [$($fieldToCheck.Name)] with value [$($fieldToCheck.Value.accountValue)] is unique."
         }
         #endregion Check property uniqueness
     }

--- a/uniquenessCheck.ps1
+++ b/uniquenessCheck.ps1
@@ -7,14 +7,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]

--- a/update.ps1
+++ b/update.ps1
@@ -3,7 +3,7 @@
 # Update account and optionally set manager
 # PowerShell V2
 #################################################
-
+$actionContext.DryRun = $false
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
@@ -49,11 +49,11 @@ function Resolve-KPNLisaError {
                 if ($null -ne $errorObjectConverted.Error.Message) {
                     $httpErrorObj.FriendlyMessage = $errorObjectConverted.Error.Message
 
-                    if ($null -ne $errorObjectConverted.Error.Code) { 
+                    if ($null -ne $errorObjectConverted.Error.Code) {
                         $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Error code: $($errorObjectConverted.Error.Code)"
                     }
 
-                    if ($null -ne $errorObjectConverted.ErrorDetails) { 
+                    if ($null -ne $errorObjectConverted.ErrorDetails) {
                         $httpErrorObj.FriendlyMessage = $httpErrorObj.FriendlyMessage + ". Additional details: $($errorObjectConverted.ErrorDetails | ConvertTo-Json)"
                     }
                 }
@@ -95,7 +95,9 @@ try {
     $account = [PSCustomObject]$actionContext.Data.PsObject.Copy()
 
     # Define properties to query
-    $accountPropertiesToQuery = @("id") + $account.PsObject.Properties.Name | Select-Object -Unique
+    # Automatically replaced by HelloID for compatibility with release 2025.04
+    # $accountPropertiesToQuery = @("id") + $account.PsObject.Properties.Name | Select-Object -Unique
+    $accountPropertiesToQuery = @("id") + $outputContext.Data.PsObject.Properties.Name | Select-Object -Unique
 
     # Remove properties of account object with null-values
     $account.PsObject.Properties | ForEach-Object {
@@ -113,22 +115,22 @@ try {
 
     #region Verify account reference
     $actionMessage = "verifying account reference"
-    
+
     if ([string]::IsNullOrEmpty($($actionContext.References.Account))) {
         throw "The account reference could not be found"
     }
     #endregion Verify account reference
-    
+
     #region Create access token
     $actionMessage = "creating access token"
-    
+
     $createAccessTokenBody = @{
         grant_type    = "client_credentials"
         client_id     = $actionContext.Configuration.EntraIDAppId
         client_secret = $actionContext.Configuration.EntraIDAppSecret
         scope         = $actionContext.Configuration.KPNMWPScope
     }
-    
+
     $createAccessTokenSplatParams = @{
         Uri             = "https://login.microsoftonline.com/$($actionContext.Configuration.EntraIDTenantID)/oauth2/v2.0/token/"
         Headers         = $headers
@@ -139,25 +141,25 @@ try {
         Verbose         = $false
         ErrorAction     = "Stop"
     }
-    
-    $createAccessTokenResponse = Invoke-RestMethod @createAccessTokenSplatParams
-    
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResponse.expiresIn | ConvertTo-Json)"
+
+    $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
+
+    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
-    
+
     #region Create headers
     $actionMessage = "creating headers"
-    
+
     $headers = @{
         "Accept"          = "application/json"
         "Content-Type"    = "application/json;charset=utf-8"
         "Mwp-Api-Version" = "1.0"
     }
-    
+
     Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
-    $headers['Authorization'] = "Bearer $($createAccessTokenResponse.access_token)"
+    $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
     #endregion Create headers
 
     #region Get account
@@ -174,7 +176,7 @@ try {
         ErrorAction = "Stop"
     }
 
-    Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
+    Write-Information "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
 
     # Add header after printing splat
     $getKPNLisaAccountSplatParams['Headers'] = $headers
@@ -182,8 +184,8 @@ try {
     $getKPNLisaAccountResponse = $null
     $getKPNLisaAccountResponse = Invoke-RestMethod @getKPNLisaAccountSplatParams
     $correlatedAccount = $getKPNLisaAccountResponse
-        
-    Write-Verbose "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
+
+    Write-Information "Queried account with ID: $($actionContext.References.Account). Result: $($correlatedAccount | ConvertTo-Json)"
     #endregion Get account
 
     #region Calulate action
@@ -198,26 +200,26 @@ try {
             #region Get manager of account
             # API docs: https://mwpapi.kpnwerkplek.com/index.html, specific API call: GET /api/users/{identifier}/manager
             $actionMessage = "querying manager of account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)"
-    
+
             $getKPNLisaAccountManagerSplatParams = @{
                 Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($actionContext.References.Account)/manager"
                 Method      = "GET"
                 Verbose     = $false
                 ErrorAction = "Stop"
             }
-    
+
             Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
-    
+
             # Add header after printing splat
             $getKPNLisaAccountManagerSplatParams['Headers'] = $headers
-    
+
             $getKPNLisaAccountManagerResponse = $null
             $getKPNLisaAccountManagerResponse = Invoke-RestMethod @getKPNLisaAccountManagerSplatParams
             $previousManagerId = $getKPNLisaAccountManagerResponse.id
-            
+
             Write-Verbose "Queried manager of account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Result: $($getKPNLisaAccountManagerResponse | ConvertTo-Json)"
             #endregion Get manager of  account
-    
+
             #region Calulate manager action
             if ($actionContext.References.ManagerAccount -ne $previousManagerId) {
                 if (-not[String]::IsNullOrEmpty(($actionContext.References.ManagerAccount))) {
@@ -284,7 +286,7 @@ try {
         }
         else {
             $actionAccount = "NoChanges"
-        }            
+        }
 
         Write-Verbose "Compared current account to mapped properties. Result: $actionAccount"
     }
@@ -294,8 +296,9 @@ try {
     elseif (($correlatedAccount | Measure-Object).count -gt 1) {
         $actionAccount = "MultipleFound"
     }
+    Write-Information "Action: $actionAccount"
     #endregion Calulate action
-    
+
     #region Process
     switch ($actionAccount) {
         "Update" {
@@ -314,11 +317,15 @@ try {
                 # Update $outputContext.Data with updated fields
                 $outputContext.Data | Add-Member -MemberType NoteProperty -Name $accountNewProperty.Name -Value $accountNewProperty.Value -Force
             }
-            # Convert the properties of custom account object for update containing "TRUE" or "FALSE" to boolean 
+            # Convert the properties of custom account object for update containing "TRUE" or "FALSE" to boolean
             $updateAccountBody = Convert-StringToBoolean $updateAccountBody
 
             if ($updateAccountBody.PSObject.Properties.Name -Contains 'BusinessPhones' -And $updateAccountBody.BusinessPhones -is [string]) {
-                $updateAccountBody.BusinessPhones = @($updateAccountBody.BusinessPhones)
+                if ([string]::IsNullOrEmpty($updateAccountBody.BusinessPhones)) {
+                    $updateAccountBody.BusinessPhones = @()
+                } else {
+                    $updateAccountBody.BusinessPhones = @($updateAccountBody.BusinessPhones)
+                }
             }
 
             $updateAccountSplatParams = @{
@@ -417,7 +424,7 @@ try {
 
                     $setManagerResponse = Invoke-RestMethod @setManagerSplatParams
 
-                    #region Set ManagerId 
+                    #region Set ManagerId
                     $outputContext.Data | Add-Member -MemberType NoteProperty -Name "managerId" -Value $actionContext.References.ManagerAccount -Force
                     #endregion Set ManagerId
 

--- a/update.ps1
+++ b/update.ps1
@@ -136,7 +136,7 @@ try {
 
     $createAccessTokenResonse = Invoke-RestMethod @createAccessTokenSplatParams
 
-    Write-Verbose "Created access token. Expires in: $($createAccessTokenResonse.expiresIn | ConvertTo-Json)"
+    Write-Information "Created access token. Expires in: $($createAccessTokenResonse.expiresIn | ConvertTo-Json)"
     #endregion Create access token
 
     #region Create headers
@@ -148,7 +148,7 @@ try {
         "Mwp-Api-Version" = "1.0"
     }
 
-    Write-Verbose "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
+    Write-Information "Created headers. Result (without Authorization): $($headers | ConvertTo-Json)."
 
     # Add Authorization after printing splat
     $headers['Authorization'] = "Bearer $($createAccessTokenResonse.access_token)"
@@ -200,7 +200,7 @@ try {
                 ErrorAction = "Stop"
             }
 
-            Write-Verbose "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($getKPNLisaAccountSplatParams | ConvertTo-Json)"
 
             # Add header after printing splat
             $getKPNLisaAccountManagerSplatParams['Headers'] = $headers
@@ -209,7 +209,7 @@ try {
             $getKPNLisaAccountManagerResponse = Invoke-RestMethod @getKPNLisaAccountManagerSplatParams
             $previousManagerId = $getKPNLisaAccountManagerResponse.id
 
-            Write-Verbose "Queried manager of account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Result: $($getKPNLisaAccountManagerResponse | ConvertTo-Json)"
+            Write-Information "Queried manager of account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Result: $($getKPNLisaAccountManagerResponse | ConvertTo-Json)"
             #endregion Get manager of  account
 
             #region Calulate manager action
@@ -272,7 +272,7 @@ try {
                 $accountChangedPropertiesObject.NewValues.$($accountNewProperty.Name) = $accountNewProperty.Value
             }
 
-            Write-Verbose "Changed properties: $($accountChangedPropertiesObject | ConvertTo-Json)"
+            Write-Information "Changed properties: $($accountChangedPropertiesObject | ConvertTo-Json)"
 
             $actionAccount = "Update"
         }
@@ -280,7 +280,7 @@ try {
             $actionAccount = "NoChanges"
         }
 
-        Write-Verbose "Compared current account to mapped properties. Result: $actionAccount"
+        Write-Information "Compared current account to mapped properties. Result: $actionAccount"
     }
     elseif (($correlatedAccount | Measure-Object).count -eq 0) {
         $actionAccount = "NotFound"
@@ -329,7 +329,7 @@ try {
                 ErrorAction = "Stop"
             }
 
-            Write-Verbose "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
+            Write-Information "SplatParams: $($updateAccountSplatParams | ConvertTo-Json)"
 
             if (-Not($actionContext.DryRun -eq $true)) {
                 # Add header after printing splat
@@ -408,7 +408,7 @@ try {
                     ErrorAction = "Stop"
                 }
 
-                Write-Verbose "SplatParams: $($setManagerSplatParams | ConvertTo-Json)"
+                Write-Information "SplatParams: $($setManagerSplatParams | ConvertTo-Json)"
 
                 if (-Not($actionContext.DryRun -eq $true)) {
                     # Add header after printing splat
@@ -464,7 +464,7 @@ try {
                     ErrorAction = "Stop"
                 }
 
-                Write-Verbose "SplatParams: $($clearManagerSplatParams | ConvertTo-Json)"
+                Write-Information "SplatParams: $($clearManagerSplatParams | ConvertTo-Json)"
 
                 if (-Not($actionContext.DryRun -eq $true)) {
                     # Add header after printing splat

--- a/update.ps1
+++ b/update.ps1
@@ -305,7 +305,7 @@ try {
 
             # Set $outputContext.Data with correlated account
             $outputContext.Data = $correlatedAccount.PsObject.Copy()
-            
+
             # Create custom account object for update and set with updated properties
             $updateAccountBody = [PSCustomObject]@{}
             foreach ($accountNewProperty in $accountNewProperties) {
@@ -316,6 +316,10 @@ try {
             }
             # Convert the properties of custom account object for update containing "TRUE" or "FALSE" to boolean 
             $updateAccountBody = Convert-StringToBoolean $updateAccountBody
+
+            if ($updateAccountBody.PSObject.Properties.Name -Contains 'BusinessPhones' -And $updateAccountBody.BusinessPhones -is [string]) {
+                $updateAccountBody.BusinessPhones = @($updateAccountBody.BusinessPhones)
+            }
 
             $updateAccountSplatParams = @{
                 Uri         = "$($actionContext.Configuration.MWPApiBaseUrl)/users/$($outputContext.AccountReference)/bulk"
@@ -389,7 +393,7 @@ try {
     #endregion Process
 
     #region Manager
-    if ($actionContext.Configuration.updateManagerOnUpdate -eq $true) {      
+    if ($actionContext.Configuration.updateManagerOnUpdate -eq $true) {
         switch ($actionManager) {
             "Update" {
                 #region Set Manager
@@ -445,7 +449,7 @@ try {
                         IsError = $false
                     })
                 #endregion No changes
-    
+
                 break
             }
 

--- a/update.ps1
+++ b/update.ps1
@@ -7,14 +7,6 @@ $actionContext.DryRun = $false
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Resolve-KPNLisaError {
     [CmdletBinding()]


### PR DESCRIPTION
## [2.2.0] - 2026-02-13
### Added
- Import scripts for entitlements and authentication methods.
- Refactored grant and revoke scripts for authentication methods to use a flat array structure and improved logging.
- Improved audit logging and fallback display names in all permission scripts.
- Updated README with all used API endpoints and best practices for required "None" mappings.
- Confirmed and documented use of `$outputContext.Data` for required attributes with "None" mapping.

### Changed
- Adjusted scripts for import functionality and proper support for the PhoneBusiness attribute.
- Refactored and standardized code formatting across all scripts for consistency.
- Improved phone number comparison logic to ignore spaces and ensure robust matching.
- Enhanced error handling and logging for better troubleshooting.

### Fixed
- Hotfix to support no mapped fields on delete actions.
- Fixed issues with phone number detection and comparison in authentication scripts.
- Fixed audit logging to always include PermissionDisplayName where possible.
- Fixed bug: BusinessPhones should be an array, not a string, in the compare attribute logic ([#6](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-KPN-Lisa/issues/6)).
- Fixed minor bugs and improved code hygiene (removed trailing whitespace, unnecessary blank lines, etc.).